### PR TITLE
feat(pipeline): ニュース収集パイプラインステップ (#4)

### DIFF
--- a/backend/app/api/episodes.py
+++ b/backend/app/api/episodes.py
@@ -10,11 +10,9 @@ from sqlalchemy.orm import selectinload
 
 from app.database import get_session
 from app.models import Episode
-from app.pipeline.engine import PipelineEngine
+from app.pipeline import engine
 
 router = APIRouter(tags=["episodes"])
-
-engine = PipelineEngine()
 
 
 # --- Schemas ---

--- a/backend/app/api/pipeline.py
+++ b/backend/app/api/pipeline.py
@@ -9,11 +9,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
 from app.models import PipelineStep, StepName
-from app.pipeline.engine import PipelineEngine
+from app.pipeline import engine
 
 router = APIRouter(tags=["pipeline"])
-
-engine = PipelineEngine()
 
 
 # --- Schemas ---

--- a/backend/app/pipeline/__init__.py
+++ b/backend/app/pipeline/__init__.py
@@ -1,0 +1,9 @@
+"""Pipeline engine singleton with registered steps."""
+
+from app.pipeline.collector import CollectorStep
+from app.pipeline.engine import PipelineEngine
+
+engine = PipelineEngine()
+engine.register_step(CollectorStep)
+
+__all__ = ["CollectorStep", "PipelineEngine", "engine"]

--- a/backend/app/pipeline/collector.py
+++ b/backend/app/pipeline/collector.py
@@ -1,0 +1,79 @@
+"""Step 1: News collection pipeline step."""
+
+import logging
+
+from sqlalchemy import select
+
+from app.database import async_session
+from app.models import NewsItem, StepName
+from app.pipeline.base import BaseStep
+from app.services.scraper import ScraperService
+
+logger = logging.getLogger(__name__)
+
+
+class CollectorStep(BaseStep):
+    """Collect news articles from configured sources."""
+
+    @property
+    def step_name(self) -> StepName:
+        return StepName.COLLECTION
+
+    async def execute(self, episode_id: int, input_data: dict) -> dict:
+        """Scrape news sources and create NewsItem records.
+
+        Idempotent: re-running skips articles whose URL already exists for the episode.
+
+        Returns:
+            dict with articles_found, articles_saved, and articles list.
+        """
+        service = ScraperService()
+        scraped = await service.collect_all()
+
+        articles_saved = 0
+        articles_list: list[dict] = []
+
+        async with async_session() as session:
+            # Get existing URLs for this episode to ensure idempotency
+            result = await session.execute(select(NewsItem.source_url).where(NewsItem.episode_id == episode_id))
+            existing_urls = {row[0] for row in result.all()}
+
+            for article in scraped:
+                if article.url in existing_urls:
+                    continue
+
+                news_item = NewsItem(
+                    episode_id=episode_id,
+                    title=article.title,
+                    summary=article.summary,
+                    source_url=article.url,
+                    source_name=article.source_name,
+                )
+                session.add(news_item)
+                existing_urls.add(article.url)
+                articles_saved += 1
+
+                articles_list.append(
+                    {
+                        "title": article.title,
+                        "url": article.url,
+                        "source_name": article.source_name,
+                        "summary": article.summary,
+                        "published_at": article.published_at.isoformat() if article.published_at else None,
+                    }
+                )
+
+            await session.commit()
+
+        logger.info(
+            "Episode %d: found %d articles, saved %d new",
+            episode_id,
+            len(scraped),
+            articles_saved,
+        )
+
+        return {
+            "articles_found": len(scraped),
+            "articles_saved": articles_saved,
+            "articles": articles_list,
+        }

--- a/backend/app/services/scraper.py
+++ b/backend/app/services/scraper.py
@@ -1,0 +1,95 @@
+"""Scraper service that orchestrates all news scrapers."""
+
+import asyncio
+import logging
+from urllib.parse import urlparse
+
+import httpx
+
+from app.services.scrapers import DEFAULT_SCRAPERS
+from app.services.scrapers.base import BaseScraper, ScrapedArticle, ScrapeResult
+
+logger = logging.getLogger(__name__)
+
+USER_AGENT = "AINewsRadio/1.0"
+
+
+class ScraperService:
+    """Orchestrates multiple scrapers with parallel execution and deduplication.
+
+    Scrapers can be dynamically added or removed at runtime.
+    """
+
+    def __init__(self) -> None:
+        self._registry: dict[str, type[BaseScraper]] = {}
+        # Register default scrapers
+        for cls in DEFAULT_SCRAPERS:
+            self.register(cls)
+
+    def register(self, scraper_class: type[BaseScraper]) -> None:
+        """Register a scraper. Keyed by source_name."""
+        instance = scraper_class()
+        self._registry[instance.source_name] = scraper_class
+
+    def unregister(self, source_name: str) -> None:
+        """Remove a scraper by source_name."""
+        self._registry.pop(source_name, None)
+
+    @property
+    def registered_names(self) -> list[str]:
+        """List of currently registered scraper source names."""
+        return list(self._registry.keys())
+
+    async def collect_all(self) -> list[ScrapedArticle]:
+        """Run all registered scrapers in parallel and return deduplicated articles.
+
+        Error isolation: if one scraper fails, others still return results.
+        """
+        if not self._registry:
+            return []
+
+        async with httpx.AsyncClient(
+            headers={"User-Agent": USER_AGENT},
+            follow_redirects=True,
+        ) as client:
+            tasks = [cls().scrape(client) for cls in self._registry.values()]
+            results: list[ScrapeResult] = await asyncio.gather(*tasks, return_exceptions=False)
+
+        all_articles: list[ScrapedArticle] = []
+        for result in results:
+            if result.error:
+                logger.warning("Scraper %s failed: %s", result.source_name, result.error)
+            else:
+                logger.info("Scraper %s: %d articles", result.source_name, len(result.articles))
+            all_articles.extend(result.articles)
+
+        return _deduplicate(all_articles)
+
+
+def _normalize_url(url: str) -> str:
+    """Normalize URL for deduplication.
+
+    - Lowercase scheme and host
+    - Remove trailing slash
+    - Remove fragment
+    """
+    parsed = urlparse(url)
+    normalized = parsed._replace(
+        scheme=parsed.scheme.lower(),
+        netloc=parsed.netloc.lower(),
+        path=parsed.path.rstrip("/") or "/",
+        fragment="",
+    )
+    return normalized.geturl()
+
+
+def _deduplicate(articles: list[ScrapedArticle]) -> list[ScrapedArticle]:
+    """Remove duplicate articles based on normalized URL."""
+    seen: set[str] = set()
+    unique: list[ScrapedArticle] = []
+    for article in articles:
+        key = _normalize_url(article.url)
+        if key not in seen:
+            seen.add(key)
+            unique.append(article)
+    return unique

--- a/backend/app/services/scrapers/__init__.py
+++ b/backend/app/services/scrapers/__init__.py
@@ -1,0 +1,26 @@
+"""News scrapers for various Kumamoto news sources."""
+
+from app.services.scrapers.base import BaseScraper, ScrapedArticle, ScrapeResult
+from app.services.scrapers.kab import KABScraper
+from app.services.scrapers.nhk_kumamoto import NHKKumamotoScraper
+from app.services.scrapers.pref_kumamoto import PrefKumamotoScraper
+from app.services.scrapers.rkk import RKKScraper
+
+# NHKKumamotoScraper is excluded: RSS feed now requires JWT authentication.
+# Can be re-added via ScraperService.register() if auth becomes available.
+DEFAULT_SCRAPERS: list[type[BaseScraper]] = [
+    PrefKumamotoScraper,
+    RKKScraper,
+    KABScraper,
+]
+
+__all__ = [
+    "DEFAULT_SCRAPERS",
+    "BaseScraper",
+    "KABScraper",
+    "NHKKumamotoScraper",
+    "PrefKumamotoScraper",
+    "RKKScraper",
+    "ScrapedArticle",
+    "ScrapeResult",
+]

--- a/backend/app/services/scrapers/base.py
+++ b/backend/app/services/scrapers/base.py
@@ -1,0 +1,55 @@
+"""Base classes for news scrapers."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+
+import httpx
+
+
+@dataclass(frozen=True)
+class ScrapedArticle:
+    """A single scraped news article."""
+
+    title: str
+    url: str
+    source_name: str
+    summary: str | None = None
+    published_at: datetime | None = None
+
+
+@dataclass
+class ScrapeResult:
+    """Result from a single scraper run."""
+
+    source_name: str
+    articles: list[ScrapedArticle] = field(default_factory=list)
+    error: str | None = None
+
+
+class BaseScraper(ABC):
+    """Abstract base class for news scrapers."""
+
+    @property
+    @abstractmethod
+    def source_name(self) -> str:
+        """Human-readable name of the news source."""
+        ...
+
+    @property
+    @abstractmethod
+    def base_url(self) -> str:
+        """Base URL of the news source."""
+        ...
+
+    @abstractmethod
+    async def scrape(self, client: httpx.AsyncClient) -> ScrapeResult:
+        """Scrape articles from the news source.
+
+        Args:
+            client: Shared httpx async client for connection pooling.
+
+        Returns:
+            ScrapeResult with articles or error information.
+        """
+        ...

--- a/backend/app/services/scrapers/kab.py
+++ b/backend/app/services/scrapers/kab.py
@@ -1,0 +1,136 @@
+"""KAB Kumamoto Asahi Broadcasting scraper (RSS with HTML fallback)."""
+
+import logging
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+from urllib.parse import urljoin
+from xml.etree.ElementTree import Element, fromstring
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+
+from app.services.scrapers.base import BaseScraper, ScrapedArticle, ScrapeResult
+
+logger = logging.getLogger(__name__)
+
+RSS_URL = "https://www.kab.co.jp/rss/"
+HTML_URL = "https://www.kab.co.jp/news/"
+
+
+class KABScraper(BaseScraper):
+    """Scraper for KAB Kumamoto Asahi Broadcasting. Tries RSS first, falls back to HTML."""
+
+    @property
+    def source_name(self) -> str:
+        return "KAB熊本朝日放送"
+
+    @property
+    def base_url(self) -> str:
+        return "https://www.kab.co.jp"
+
+    async def scrape(self, client: httpx.AsyncClient) -> ScrapeResult:
+        """Try RSS feed first, fall back to HTML scraping on failure."""
+        # Try RSS first
+        try:
+            resp = await client.get(RSS_URL, timeout=15.0)
+            resp.raise_for_status()
+            articles = self._parse_rss(resp.text)
+            if articles:
+                return ScrapeResult(source_name=self.source_name, articles=articles)
+        except Exception as e:
+            logger.info("KAB RSS failed, trying HTML fallback: %s", e)
+
+        # Fallback to HTML
+        try:
+            resp = await client.get(HTML_URL, timeout=15.0)
+            resp.raise_for_status()
+            articles = self._parse_html(resp.text)
+            return ScrapeResult(source_name=self.source_name, articles=articles)
+        except Exception as e:
+            logger.warning("KAB scrape failed (both RSS and HTML): %s", e)
+            return ScrapeResult(source_name=self.source_name, error=str(e))
+
+    def _parse_rss(self, xml_text: str) -> list[ScrapedArticle]:
+        """Parse WordPress RSS feed."""
+        root = fromstring(xml_text)
+        articles: list[ScrapedArticle] = []
+
+        for item in root.iter("item"):
+            title = _text(item, "title")
+            link = _text(item, "link")
+            if not title or not link:
+                continue
+
+            pub_date = _text(item, "pubDate")
+            published_at = _parse_rfc2822(pub_date) if pub_date else None
+            description = _text(item, "description")
+
+            articles.append(
+                ScrapedArticle(
+                    title=title.strip(),
+                    url=link.strip(),
+                    source_name=self.source_name,
+                    summary=description.strip() if description else None,
+                    published_at=published_at,
+                )
+            )
+
+        return articles
+
+    def _parse_html(self, html: str) -> list[ScrapedArticle]:
+        """Parse KAB news list HTML as fallback.
+
+        Only matches actual article links (/news/article/DIGITS),
+        skipping category pages, series, and navigation.
+        """
+        import re
+
+        soup = BeautifulSoup(html, "html.parser")
+        articles: list[ScrapedArticle] = []
+        seen_urls: set[str] = set()
+
+        for link_tag in soup.select("a[href*='/news/article/']"):
+            if not isinstance(link_tag, Tag):
+                continue
+            href = link_tag.get("href", "")
+            if not isinstance(href, str):
+                continue
+            # Strict: only /news/article/<digits>
+            if not re.search(r"/news/article/\d+", href):
+                continue
+
+            url = urljoin(self.base_url, href)
+            if url in seen_urls:
+                continue
+            seen_urls.add(url)
+
+            # Prefer title from h3
+            title_el = link_tag.find("h3")
+            title = title_el.get_text(strip=True) if title_el else link_tag.get_text(strip=True)
+            if not title:
+                continue
+
+            articles.append(
+                ScrapedArticle(
+                    title=title,
+                    url=url,
+                    source_name=self.source_name,
+                )
+            )
+
+        return articles
+
+
+def _text(element: Element, tag: str) -> str | None:
+    """Get text content of a child element."""
+    child = element.find(tag)
+    return child.text if child is not None and child.text else None
+
+
+def _parse_rfc2822(date_str: str) -> datetime | None:
+    """Parse RFC 2822 date string to timezone-aware datetime."""
+    try:
+        dt = parsedate_to_datetime(date_str)
+        return dt.astimezone(UTC)
+    except (ValueError, TypeError):
+        return None

--- a/backend/app/services/scrapers/nhk_kumamoto.py
+++ b/backend/app/services/scrapers/nhk_kumamoto.py
@@ -1,0 +1,79 @@
+"""NHK Kumamoto news scraper (RSS feed)."""
+
+import logging
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+from xml.etree.ElementTree import Element, fromstring
+
+import httpx
+
+from app.services.scrapers.base import BaseScraper, ScrapedArticle, ScrapeResult
+
+logger = logging.getLogger(__name__)
+
+RSS_URL = "https://www3.nhk.or.jp/lnews/kumamoto/rss.xml"
+
+
+class NHKKumamotoScraper(BaseScraper):
+    """Scraper for NHK Kumamoto using RSS feed."""
+
+    @property
+    def source_name(self) -> str:
+        return "NHK熊本"
+
+    @property
+    def base_url(self) -> str:
+        return "https://www3.nhk.or.jp/lnews/kumamoto/"
+
+    async def scrape(self, client: httpx.AsyncClient) -> ScrapeResult:
+        """Fetch and parse NHK Kumamoto RSS feed."""
+        try:
+            resp = await client.get(RSS_URL, timeout=15.0)
+            resp.raise_for_status()
+            articles = self._parse_rss(resp.text)
+            return ScrapeResult(source_name=self.source_name, articles=articles)
+        except Exception as e:
+            logger.warning("NHK Kumamoto scrape failed: %s", e)
+            return ScrapeResult(source_name=self.source_name, error=str(e))
+
+    def _parse_rss(self, xml_text: str) -> list[ScrapedArticle]:
+        """Parse RSS XML into ScrapedArticle list."""
+        root = fromstring(xml_text)
+        articles: list[ScrapedArticle] = []
+
+        for item in root.iter("item"):
+            title = _text(item, "title")
+            link = _text(item, "link")
+            if not title or not link:
+                continue
+
+            pub_date = _text(item, "pubDate")
+            published_at = _parse_rfc2822(pub_date) if pub_date else None
+            description = _text(item, "description")
+
+            articles.append(
+                ScrapedArticle(
+                    title=title.strip(),
+                    url=link.strip(),
+                    source_name=self.source_name,
+                    summary=description.strip() if description else None,
+                    published_at=published_at,
+                )
+            )
+
+        return articles
+
+
+def _text(element: Element, tag: str) -> str | None:
+    """Get text content of a child element."""
+    child = element.find(tag)
+    return child.text if child is not None and child.text else None
+
+
+def _parse_rfc2822(date_str: str) -> datetime | None:
+    """Parse RFC 2822 date string to timezone-aware datetime."""
+    try:
+        dt = parsedate_to_datetime(date_str)
+        return dt.astimezone(UTC)
+    except (ValueError, TypeError):
+        return None

--- a/backend/app/services/scrapers/pref_kumamoto.py
+++ b/backend/app/services/scrapers/pref_kumamoto.py
@@ -1,0 +1,84 @@
+"""Kumamoto Prefecture official website scraper (RSS 1.0 / RDF)."""
+
+import logging
+from datetime import datetime
+from xml.etree.ElementTree import fromstring
+
+import httpx
+
+from app.services.scrapers.base import BaseScraper, ScrapedArticle, ScrapeResult
+
+logger = logging.getLogger(__name__)
+
+RSS_URL = "https://www.pref.kumamoto.jp/rss/10/list3.xml"
+
+# RDF/RSS 1.0 namespaces
+_NS = {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rss": "http://purl.org/rss/1.0/",
+    "dc": "http://purl.org/dc/elements/1.1/",
+}
+
+
+class PrefKumamotoScraper(BaseScraper):
+    """Scraper for Kumamoto Prefecture official RSS feed (RDF 1.0)."""
+
+    @property
+    def source_name(self) -> str:
+        return "熊本県公式"
+
+    @property
+    def base_url(self) -> str:
+        return "https://www.pref.kumamoto.jp"
+
+    async def scrape(self, client: httpx.AsyncClient) -> ScrapeResult:
+        """Fetch and parse Kumamoto Prefecture RSS feed."""
+        try:
+            resp = await client.get(RSS_URL, timeout=15.0)
+            resp.raise_for_status()
+            articles = self._parse_rss(resp.text)
+            return ScrapeResult(source_name=self.source_name, articles=articles)
+        except Exception as e:
+            logger.warning("Pref Kumamoto scrape failed: %s", e)
+            return ScrapeResult(source_name=self.source_name, error=str(e))
+
+    def _parse_rss(self, xml_text: str) -> list[ScrapedArticle]:
+        """Parse RSS 1.0 (RDF) XML into ScrapedArticle list."""
+        root = fromstring(xml_text)
+        articles: list[ScrapedArticle] = []
+
+        for item in root.findall("rss:item", _NS):
+            title_el = item.find("rss:title", _NS)
+            link_el = item.find("rss:link", _NS)
+            if title_el is None or link_el is None:
+                continue
+            title = title_el.text
+            link = link_el.text
+            if not title or not link:
+                continue
+
+            desc_el = item.find("rss:description", _NS)
+            description = desc_el.text if desc_el is not None and desc_el.text else None
+
+            date_el = item.find("dc:date", _NS)
+            published_at = _parse_iso_date(date_el.text) if date_el is not None and date_el.text else None
+
+            articles.append(
+                ScrapedArticle(
+                    title=title.strip(),
+                    url=link.strip(),
+                    source_name=self.source_name,
+                    summary=description.strip() if description else None,
+                    published_at=published_at,
+                )
+            )
+
+        return articles
+
+
+def _parse_iso_date(date_str: str) -> datetime | None:
+    """Parse ISO 8601 date string (with timezone)."""
+    try:
+        return datetime.fromisoformat(date_str)
+    except (ValueError, TypeError):
+        return None

--- a/backend/app/services/scrapers/rkk.py
+++ b/backend/app/services/scrapers/rkk.py
@@ -1,0 +1,73 @@
+"""RKK Kumamoto Broadcasting scraper (via TBS News Dig)."""
+
+import logging
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+
+from app.services.scrapers.base import BaseScraper, ScrapedArticle, ScrapeResult
+
+logger = logging.getLogger(__name__)
+
+# rkk.jp/news/ redirects to TBS News Dig
+NEWS_URL = "https://newsdig.tbs.co.jp/list/rkk"
+
+
+class RKKScraper(BaseScraper):
+    """Scraper for RKK Kumamoto Broadcasting via TBS News Dig."""
+
+    @property
+    def source_name(self) -> str:
+        return "RKK熊本放送"
+
+    @property
+    def base_url(self) -> str:
+        return "https://newsdig.tbs.co.jp"
+
+    async def scrape(self, client: httpx.AsyncClient) -> ScrapeResult:
+        """Fetch and parse TBS News Dig RKK page."""
+        try:
+            resp = await client.get(NEWS_URL, timeout=15.0)
+            resp.raise_for_status()
+            articles = self._parse_html(resp.text)
+            return ScrapeResult(source_name=self.source_name, articles=articles)
+        except Exception as e:
+            logger.warning("RKK scrape failed: %s", e)
+            return ScrapeResult(source_name=self.source_name, error=str(e))
+
+    def _parse_html(self, html: str) -> list[ScrapedArticle]:
+        """Parse TBS News Dig HTML for RKK articles."""
+        soup = BeautifulSoup(html, "html.parser")
+        articles: list[ScrapedArticle] = []
+        seen_urls: set[str] = set()
+
+        for link_tag in soup.select("a[href*='/articles/rkk/']"):
+            if not isinstance(link_tag, Tag):
+                continue
+            href = link_tag.get("href", "")
+            if not isinstance(href, str):
+                continue
+
+            # Extract clean URL (remove query params like ?display=1)
+            clean_href = href.split("?")[0]
+            url = f"{self.base_url}{clean_href}" if clean_href.startswith("/") else clean_href
+
+            if url in seen_urls:
+                continue
+            seen_urls.add(url)
+
+            # Title from .newsCard__title or direct text
+            title_el = link_tag.select_one(".newsCard__title")
+            title = title_el.get_text(strip=True) if title_el else link_tag.get_text(strip=True)
+            if not title:
+                continue
+
+            articles.append(
+                ScrapedArticle(
+                    title=title,
+                    url=url,
+                    source_name=self.source_name,
+                )
+            )
+
+        return articles

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -19,10 +19,9 @@ def run_pipeline_step(episode_id: int, step_name: str) -> dict:
     """Execute a pipeline step asynchronously via Celery."""
     from app.database import async_session
     from app.models import StepName
-    from app.pipeline.engine import PipelineEngine
+    from app.pipeline import engine
 
     async def _run() -> None:
-        engine = PipelineEngine()
         async with async_session() as session:
             await engine.run_step(episode_id, StepName(step_name), session)
 

--- a/backend/tests/fixtures/kab_html_sample.html
+++ b/backend/tests/fixtures/kab_html_sample.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head><title>KAB熊本朝日放送 ニュース</title></head>
+<body>
+  <nav>
+    <a href="/news/kab/incident">事件・事故</a>
+    <a href="/news/kab/politics-economy">政治・経済</a>
+    <a href="/news/series">特集</a>
+    <a href="/news/series/pickup">SERIESPICK UP</a>
+  </nav>
+  <div class="news-list">
+    <a href="/news/article/16398894" class="group">
+      <article>
+        <h3 class="line-clamp-3">「燃やすごみ」と「埋め立てごみ」同じ指定袋に　熊本市のごみ収集ルール変更を説明</h3>
+      </article>
+    </a>
+    <a href="/news/article/16398951" class="group">
+      <article>
+        <h3 class="line-clamp-3">性風俗店勤務を女性客に要求した疑いで逮捕</h3>
+      </article>
+    </a>
+    <a href="/news/article/16398998" class="group">
+      <article>
+        <h3 class="line-clamp-3">阿蘇の世界文化遺産登録を目指して　大阪でシンポジウム</h3>
+      </article>
+    </a>
+  </div>
+  <a href="/news/kab/page2">もっと見る</a>
+  <a href="/news/kab">もっと見る</a>
+  <a href="/news/kab/live">LIVE</a>
+</body>
+</html>

--- a/backend/tests/fixtures/kab_rss_sample.xml
+++ b/backend/tests/fixtures/kab_rss_sample.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>KAB熊本朝日放送 ニュース</title>
+    <link>https://www.kab.co.jp/news/</link>
+    <description>KAB熊本朝日放送のニュース</description>
+    <item>
+      <title>熊本空港の新ターミナル利用者数100万人突破</title>
+      <link>https://www.kab.co.jp/news/20260305001/</link>
+      <description>新ターミナルの利用者数が開業以来100万人を突破しました。</description>
+      <pubDate>Wed, 05 Mar 2026 08:00:00 +0900</pubDate>
+    </item>
+    <item>
+      <title>八代市で地域おこし協力隊の活動報告会</title>
+      <link>https://www.kab.co.jp/news/20260305002/</link>
+      <description>八代市の地域おこし協力隊が1年間の活動を報告しました。</description>
+      <pubDate>Wed, 05 Mar 2026 11:00:00 +0900</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/backend/tests/fixtures/nhk_rss_sample.xml
+++ b/backend/tests/fixtures/nhk_rss_sample.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>NHK熊本県のニュース</title>
+    <link>https://www3.nhk.or.jp/lnews/kumamoto/</link>
+    <description>NHK熊本県のニュース</description>
+    <item>
+      <title>熊本市で新しい交通システムの実証実験始まる</title>
+      <link>https://www3.nhk.or.jp/lnews/kumamoto/20260305/5000012345.html</link>
+      <description>熊本市は新しい交通システムの実証実験を開始しました。</description>
+      <pubDate>Wed, 05 Mar 2026 09:00:00 +0900</pubDate>
+    </item>
+    <item>
+      <title>阿蘇山の火山活動 専門家が分析</title>
+      <link>https://www3.nhk.or.jp/lnews/kumamoto/20260305/5000012346.html</link>
+      <description>阿蘇山の最新の火山活動について専門家が分析を行いました。</description>
+      <pubDate>Wed, 05 Mar 2026 10:30:00 +0900</pubDate>
+    </item>
+    <item>
+      <title>県内の小学校で卒業式</title>
+      <link>https://www3.nhk.or.jp/lnews/kumamoto/20260305/5000012347.html</link>
+      <pubDate>Wed, 05 Mar 2026 12:00:00 +0900</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/backend/tests/fixtures/pref_kumamoto_sample.html
+++ b/backend/tests/fixtures/pref_kumamoto_sample.html
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns="http://purl.org/rss/1.0/" xml:lang="ja"
+ xmlns:dc="http://purl.org/dc/elements/1.1/"
+ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<channel rdf:about="https://www.pref.kumamoto.jp">
+    <title>熊本県RSS（緊急・重要なお知らせ）</title>
+    <link>https://www.pref.kumamoto.jp</link>
+    <description>熊本県からの情報をRSSで配信</description>
+</channel>
+<item rdf:about="https://www.pref.kumamoto.jp/soshiki/1/243373.html">
+    <title>令和7年8月豪雨に関する情報</title>
+    <link>https://www.pref.kumamoto.jp/soshiki/1/243373.html</link>
+    <description>豪雨災害に関する最新情報をお伝えします。</description>
+    <dc:date>2026-03-03T00:00:00+09:00</dc:date>
+</item>
+<item rdf:about="https://www.pref.kumamoto.jp/soshiki/1/259776.html">
+    <title>ウェブサイト復旧のお知らせ</title>
+    <link>https://www.pref.kumamoto.jp/soshiki/1/259776.html</link>
+    <description></description>
+    <dc:date>2026-02-28T00:00:00+09:00</dc:date>
+</item>
+<item rdf:about="https://www.pref.kumamoto.jp/soshiki/30/217990.html">
+    <title>インフルエンザ予防のお願い</title>
+    <link>https://www.pref.kumamoto.jp/soshiki/30/217990.html</link>
+    <dc:date>2026-02-15T00:00:00+09:00</dc:date>
+</item>
+</rdf:RDF>

--- a/backend/tests/fixtures/rkk_sample.html
+++ b/backend/tests/fixtures/rkk_sample.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head><title>TBS NEWS DIG - RKK熊本放送</title></head>
+<body>
+  <nav>
+    <a href="https://rkk.jp/index.php">ホーム</a>
+    <a href="https://newsdig.tbs.co.jp/list/rkk">ニュース</a>
+  </nav>
+  <div class="newsList">
+    <a href="/articles/rkk/2510151?display=1">
+      <div class="newsCard__title">DV理由に転居の女性　熊本市が前の住所に文書を送る「人的ミス」</div>
+    </a>
+    <a href="/articles/rkk/2510125?display=1">
+      <div class="newsCard__title">60代男性がだまし取られた額「9900万円」</div>
+    </a>
+    <a href="/articles/rkk/2509439?display=1">
+      <div class="newsCard__title">インフルエンザ警報レベルを下回る</div>
+    </a>
+    <a href="/articles/-/2509541?display=1">
+      <div class="newsCard__title">全国ニュース記事（非RKK）</div>
+    </a>
+  </div>
+</body>
+</html>

--- a/backend/tests/test_collector.py
+++ b/backend/tests/test_collector.py
@@ -1,0 +1,124 @@
+"""Tests for CollectorStep pipeline step."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import NewsItem, StepName
+from app.pipeline.collector import CollectorStep
+from app.pipeline.engine import PipelineEngine
+from app.services.scrapers.base import ScrapedArticle
+
+
+@pytest.fixture
+def collector() -> CollectorStep:
+    return CollectorStep()
+
+
+def _make_articles(n: int = 3) -> list[ScrapedArticle]:
+    """Create N sample ScrapedArticle instances."""
+    return [
+        ScrapedArticle(
+            title=f"ニュース {i}",
+            url=f"https://example.com/news/{i}",
+            source_name="TestSource",
+            summary=f"要約 {i}",
+        )
+        for i in range(n)
+    ]
+
+
+class TestCollectorStep:
+    """Tests for the collection pipeline step."""
+
+    def test_step_name(self, collector: CollectorStep):
+        assert collector.step_name == StepName.COLLECTION
+
+    @patch("app.pipeline.collector.ScraperService")
+    @patch("app.pipeline.collector.async_session")
+    async def test_execute_creates_news_items(
+        self, mock_session_factory, mock_service_cls, collector: CollectorStep, session: AsyncSession
+    ):
+        """execute() should create NewsItem records for scraped articles."""
+        # Setup mock scraper service
+        articles = _make_articles(3)
+        mock_service = AsyncMock()
+        mock_service.collect_all.return_value = articles
+        mock_service_cls.return_value = mock_service
+
+        # Use the real test session via context manager mock
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=session)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_session_factory.return_value = mock_ctx
+
+        # Create episode first
+        engine = PipelineEngine()
+        episode = await engine.create_episode("Test", session)
+
+        result = await collector.execute(episode.id, {})
+
+        assert result["articles_found"] == 3
+        assert result["articles_saved"] == 3
+        assert len(result["articles"]) == 3
+
+        # Verify NewsItems in DB
+        db_result = await session.execute(select(NewsItem).where(NewsItem.episode_id == episode.id))
+        items = db_result.scalars().all()
+        assert len(items) == 3
+
+    @patch("app.pipeline.collector.ScraperService")
+    @patch("app.pipeline.collector.async_session")
+    async def test_execute_idempotent(
+        self, mock_session_factory, mock_service_cls, collector: CollectorStep, session: AsyncSession
+    ):
+        """Running execute twice should not duplicate articles."""
+        articles = _make_articles(2)
+        mock_service = AsyncMock()
+        mock_service.collect_all.return_value = articles
+        mock_service_cls.return_value = mock_service
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=session)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_session_factory.return_value = mock_ctx
+
+        engine = PipelineEngine()
+        episode = await engine.create_episode("Test", session)
+
+        # Run twice
+        result1 = await collector.execute(episode.id, {})
+        result2 = await collector.execute(episode.id, {})
+
+        assert result1["articles_saved"] == 2
+        assert result2["articles_saved"] == 0
+
+        db_result = await session.execute(select(NewsItem).where(NewsItem.episode_id == episode.id))
+        items = db_result.scalars().all()
+        assert len(items) == 2
+
+    @patch("app.pipeline.collector.ScraperService")
+    @patch("app.pipeline.collector.async_session")
+    async def test_execute_with_no_articles(
+        self, mock_session_factory, mock_service_cls, collector: CollectorStep, session: AsyncSession
+    ):
+        """execute() with no articles returns zero counts."""
+        mock_service = AsyncMock()
+        mock_service.collect_all.return_value = []
+        mock_service_cls.return_value = mock_service
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=session)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_session_factory.return_value = mock_ctx
+
+        engine = PipelineEngine()
+        episode = await engine.create_episode("Test", session)
+
+        result = await collector.execute(episode.id, {})
+
+        assert result["articles_found"] == 0
+        assert result["articles_saved"] == 0
+        assert result["articles"] == []

--- a/backend/tests/test_scraper_service.py
+++ b/backend/tests/test_scraper_service.py
@@ -1,0 +1,116 @@
+"""Tests for ScraperService."""
+
+from app.services.scraper import ScraperService, _deduplicate, _normalize_url
+from app.services.scrapers.base import BaseScraper, ScrapedArticle, ScrapeResult
+
+
+class TestNormalizeUrl:
+    """Tests for URL normalization."""
+
+    def test_lowercase_scheme_and_host(self):
+        assert _normalize_url("HTTP://EXAMPLE.COM/path") == "http://example.com/path"
+
+    def test_remove_trailing_slash(self):
+        assert _normalize_url("https://example.com/path/") == "https://example.com/path"
+
+    def test_preserve_root_path(self):
+        assert _normalize_url("https://example.com/") == "https://example.com/"
+
+    def test_remove_fragment(self):
+        assert _normalize_url("https://example.com/page#section") == "https://example.com/page"
+
+    def test_preserve_query_string(self):
+        assert _normalize_url("https://example.com/page?id=1") == "https://example.com/page?id=1"
+
+
+class TestDeduplicate:
+    """Tests for article deduplication."""
+
+    def test_removes_exact_duplicates(self):
+        articles = [
+            ScrapedArticle(title="A", url="https://example.com/1", source_name="src"),
+            ScrapedArticle(title="A copy", url="https://example.com/1", source_name="src2"),
+        ]
+        result = _deduplicate(articles)
+        assert len(result) == 1
+        assert result[0].title == "A"
+
+    def test_removes_trailing_slash_duplicates(self):
+        articles = [
+            ScrapedArticle(title="A", url="https://example.com/path/", source_name="src"),
+            ScrapedArticle(title="B", url="https://example.com/path", source_name="src"),
+        ]
+        result = _deduplicate(articles)
+        assert len(result) == 1
+
+    def test_keeps_different_urls(self):
+        articles = [
+            ScrapedArticle(title="A", url="https://example.com/1", source_name="src"),
+            ScrapedArticle(title="B", url="https://example.com/2", source_name="src"),
+        ]
+        result = _deduplicate(articles)
+        assert len(result) == 2
+
+    def test_case_insensitive_host_dedup(self):
+        articles = [
+            ScrapedArticle(title="A", url="https://Example.COM/page", source_name="src"),
+            ScrapedArticle(title="B", url="https://example.com/page", source_name="src"),
+        ]
+        result = _deduplicate(articles)
+        assert len(result) == 1
+
+    def test_empty_list(self):
+        assert _deduplicate([]) == []
+
+
+class TestScraperServiceRegistry:
+    """Tests for dynamic scraper registration."""
+
+    def test_default_scrapers_registered(self):
+        service = ScraperService()
+        names = service.registered_names
+        # NHK excluded (JWT auth required)
+        assert "NHK熊本" not in names
+        assert "熊本県公式" in names
+        assert "RKK熊本放送" in names
+        assert "KAB熊本朝日放送" in names
+
+    def test_register_custom_scraper(self):
+        import httpx
+
+        class CustomScraper(BaseScraper):
+            @property
+            def source_name(self) -> str:
+                return "Custom"
+
+            @property
+            def base_url(self) -> str:
+                return "https://custom.example.com"
+
+            async def scrape(self, client: httpx.AsyncClient) -> ScrapeResult:
+                return ScrapeResult(source_name=self.source_name)
+
+        service = ScraperService()
+        service.register(CustomScraper)
+        assert "Custom" in service.registered_names
+
+    def test_unregister_scraper(self):
+        service = ScraperService()
+        service.unregister("熊本県公式")
+        assert "熊本県公式" not in service.registered_names
+
+    def test_unregister_nonexistent_is_noop(self):
+        service = ScraperService()
+        service.unregister("存在しないソース")  # should not raise
+
+
+class TestScraperServiceCollectAll:
+    """Tests for error isolation in collect_all."""
+
+    async def test_empty_registry_returns_empty(self):
+        service = ScraperService()
+        # Remove all default scrapers
+        for name in list(service.registered_names):
+            service.unregister(name)
+        result = await service.collect_all()
+        assert result == []

--- a/backend/tests/test_scrapers.py
+++ b/backend/tests/test_scrapers.py
@@ -1,0 +1,199 @@
+"""Tests for individual news scrapers."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+
+from app.services.scrapers.kab import KABScraper
+from app.services.scrapers.nhk_kumamoto import NHKKumamotoScraper
+from app.services.scrapers.pref_kumamoto import PrefKumamotoScraper
+from app.services.scrapers.rkk import RKKScraper
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+# --- NHK Kumamoto (RSS, excluded from default but class still works) ---
+
+
+class TestNHKKumamotoScraper:
+    """Tests for NHK Kumamoto RSS scraper."""
+
+    def test_parse_rss_extracts_articles(self):
+        scraper = NHKKumamotoScraper()
+        articles = scraper._parse_rss(_read_fixture("nhk_rss_sample.xml"))
+        assert len(articles) == 3
+
+    def test_parse_rss_article_fields(self):
+        scraper = NHKKumamotoScraper()
+        articles = scraper._parse_rss(_read_fixture("nhk_rss_sample.xml"))
+        first = articles[0]
+        assert first.title == "熊本市で新しい交通システムの実証実験始まる"
+        assert first.url == "https://www3.nhk.or.jp/lnews/kumamoto/20260305/5000012345.html"
+        assert first.source_name == "NHK熊本"
+        assert first.summary == "熊本市は新しい交通システムの実証実験を開始しました。"
+        assert first.published_at is not None
+
+    def test_parse_rss_missing_description(self):
+        scraper = NHKKumamotoScraper()
+        articles = scraper._parse_rss(_read_fixture("nhk_rss_sample.xml"))
+        third = articles[2]
+        assert third.title == "県内の小学校で卒業式"
+        assert third.summary is None
+
+    async def test_scrape_http_error_returns_error_result(self):
+        scraper = NHKKumamotoScraper()
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.get.side_effect = httpx.HTTPStatusError(
+            "Server Error",
+            request=httpx.Request("GET", "http://test"),
+            response=httpx.Response(500),
+        )
+        result = await scraper.scrape(client)
+        assert result.error is not None
+        assert result.articles == []
+
+
+# --- Pref Kumamoto (RSS 1.0 / RDF) ---
+
+
+class TestPrefKumamotoScraper:
+    """Tests for Kumamoto Prefecture RSS scraper."""
+
+    def test_parse_rss_extracts_articles(self):
+        scraper = PrefKumamotoScraper()
+        articles = scraper._parse_rss(_read_fixture("pref_kumamoto_sample.html"))
+        assert len(articles) == 3
+
+    def test_parse_rss_article_fields(self):
+        scraper = PrefKumamotoScraper()
+        articles = scraper._parse_rss(_read_fixture("pref_kumamoto_sample.html"))
+        first = articles[0]
+        assert first.title == "令和7年8月豪雨に関する情報"
+        assert first.url == "https://www.pref.kumamoto.jp/soshiki/1/243373.html"
+        assert first.source_name == "熊本県公式"
+        assert first.summary == "豪雨災害に関する最新情報をお伝えします。"
+        assert first.published_at is not None
+
+    def test_parse_rss_empty_description(self):
+        scraper = PrefKumamotoScraper()
+        articles = scraper._parse_rss(_read_fixture("pref_kumamoto_sample.html"))
+        second = articles[1]
+        assert second.title == "ウェブサイト復旧のお知らせ"
+        assert second.summary is None  # empty description
+
+    def test_parse_rss_no_description(self):
+        scraper = PrefKumamotoScraper()
+        articles = scraper._parse_rss(_read_fixture("pref_kumamoto_sample.html"))
+        third = articles[2]
+        assert third.title == "インフルエンザ予防のお願い"
+        assert third.summary is None  # no description element
+
+
+# --- RKK (TBS News Dig) ---
+
+
+class TestRKKScraper:
+    """Tests for RKK scraper via TBS News Dig."""
+
+    def test_parse_html_extracts_rkk_articles(self):
+        scraper = RKKScraper()
+        articles = scraper._parse_html(_read_fixture("rkk_sample.html"))
+        assert len(articles) == 3
+
+    def test_parse_html_article_fields(self):
+        scraper = RKKScraper()
+        articles = scraper._parse_html(_read_fixture("rkk_sample.html"))
+        assert articles[0].title == "DV理由に転居の女性　熊本市が前の住所に文書を送る「人的ミス」"
+        assert articles[0].url == "https://newsdig.tbs.co.jp/articles/rkk/2510151"
+        assert articles[0].source_name == "RKK熊本放送"
+
+    def test_parse_html_skips_non_rkk_articles(self):
+        """Should skip articles from /articles/-/ (national news)."""
+        scraper = RKKScraper()
+        articles = scraper._parse_html(_read_fixture("rkk_sample.html"))
+        urls = [a.url for a in articles]
+        assert not any("/articles/-/" in u for u in urls)
+
+    def test_parse_html_strips_query_params(self):
+        scraper = RKKScraper()
+        articles = scraper._parse_html(_read_fixture("rkk_sample.html"))
+        for a in articles:
+            assert "?" not in a.url
+
+
+# --- KAB (RSS + HTML fallback) ---
+
+
+class TestKABScraper:
+    """Tests for KAB RSS/HTML scraper."""
+
+    def test_parse_rss_extracts_articles(self):
+        scraper = KABScraper()
+        articles = scraper._parse_rss(_read_fixture("kab_rss_sample.xml"))
+        assert len(articles) == 2
+
+    def test_parse_rss_article_fields(self):
+        scraper = KABScraper()
+        articles = scraper._parse_rss(_read_fixture("kab_rss_sample.xml"))
+        first = articles[0]
+        assert first.title == "熊本空港の新ターミナル利用者数100万人突破"
+        assert first.url == "https://www.kab.co.jp/news/20260305001/"
+        assert first.source_name == "KAB熊本朝日放送"
+        assert first.published_at is not None
+
+    def test_parse_html_extracts_only_article_links(self):
+        """Should only extract /news/article/DIGITS links."""
+        scraper = KABScraper()
+        articles = scraper._parse_html(_read_fixture("kab_html_sample.html"))
+        assert len(articles) == 3
+
+    def test_parse_html_skips_category_links(self):
+        """Should skip /news/kab/*, /news/series/* links."""
+        scraper = KABScraper()
+        articles = scraper._parse_html(_read_fixture("kab_html_sample.html"))
+        urls = [a.url for a in articles]
+        assert not any("/news/kab/" in u for u in urls)
+        assert not any("/news/series/" in u for u in urls)
+
+    def test_parse_html_article_title_from_h3(self):
+        scraper = KABScraper()
+        articles = scraper._parse_html(_read_fixture("kab_html_sample.html"))
+        assert articles[0].title == "「燃やすごみ」と「埋め立てごみ」同じ指定袋に　熊本市のごみ収集ルール変更を説明"
+
+    async def test_scrape_rss_success_skips_html(self):
+        """When RSS succeeds, HTML fallback should not be called."""
+        scraper = KABScraper()
+        rss_content = _read_fixture("kab_rss_sample.xml")
+
+        client = AsyncMock(spec=httpx.AsyncClient)
+        resp = httpx.Response(200, text=rss_content, request=httpx.Request("GET", "http://test"))
+        client.get.return_value = resp
+
+        result = await scraper.scrape(client)
+        assert result.error is None
+        assert len(result.articles) == 2
+        client.get.assert_called_once()
+
+    async def test_scrape_rss_failure_falls_back_to_html(self):
+        """When RSS fails, should try HTML fallback."""
+        scraper = KABScraper()
+        html_content = _read_fixture("kab_html_sample.html")
+
+        client = AsyncMock(spec=httpx.AsyncClient)
+        rss_error = httpx.HTTPStatusError(
+            "Not Found",
+            request=httpx.Request("GET", "http://test"),
+            response=httpx.Response(404),
+        )
+        html_resp = httpx.Response(200, text=html_content, request=httpx.Request("GET", "http://test"))
+        client.get.side_effect = [rss_error, html_resp]
+
+        result = await scraper.scrape(client)
+        assert result.error is None
+        assert len(result.articles) == 3
+        assert client.get.call_count == 2


### PR DESCRIPTION
## Summary

- Webスクレイパー基盤（BaseScraper ABC）と動的レジストリ付き ScraperService を実装
- 3ソースの個別スクレイパー: 熊本県公式(RSS 1.0), RKK/TBS News Dig(HTML), KAB(RSS+HTMLフォールバック)
- CollectorStep パイプラインステップ: 記事収集 → NewsItem作成 → needs_approval 状態に遷移
- PipelineEngine をシングルトン化し、tasks.py / API から共有参照に統一
- NHK熊本は JWT認証必須のため DEFAULT_SCRAPERS から除外（クラスは保持、将来 register() で追加可能）

## Test plan

- [x] `python -m pytest tests/ --timeout=10` — 66 passed
- [x] `ruff check && ruff format --check` — all clean
- [x] `docker compose up -d --build` → エピソード作成 → Collection実行 → 68記事収集 → needs_approval 確認
- [x] UIダッシュボードからの動作確認

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)