### PR TITLE
feat(ui): パイプラインステップのデータ詳細表示

### DIFF
--- a/backend/app/api/episodes.py
+++ b/backend/app/api/episodes.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.database import get_session
-from app.models import Episode
+from app.models import Episode, NewsItem
 from app.pipeline import engine
 
 router = APIRouter(tags=["episodes"])
@@ -30,11 +30,14 @@ class StepResponse(BaseModel):
     id: int
     step_name: str
     status: str
+    input_data: dict | None = None
+    output_data: dict | None = None
     started_at: datetime | None = None
     completed_at: datetime | None = None
     approved_at: datetime | None = None
     rejected_at: datetime | None = None
     rejection_reason: str | None = None
+    created_at: datetime | None = None
 
     model_config = {"from_attributes": True}
 
@@ -57,6 +60,26 @@ class EpisodeListResponse(BaseModel):
 
     episodes: list[EpisodeResponse]
     total: int
+
+
+class NewsItemResponse(BaseModel):
+    """Response for a single news item."""
+
+    id: int
+    episode_id: int
+    title: str
+    summary: str | None = None
+    source_url: str
+    source_name: str
+    fact_check_status: str | None = None
+    fact_check_score: int | None = None
+    fact_check_details: str | None = None
+    reference_urls: list[str] | None = None
+    analysis_data: dict | None = None
+    script_text: str | None = None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
 
 
 # --- Endpoints ---
@@ -94,3 +117,20 @@ async def get_episode(
         return await engine.get_episode_with_steps(episode_id, session)
     except Exception as e:
         raise HTTPException(status_code=404, detail="Episode not found") from e
+
+
+@router.get(
+    "/episodes/{episode_id}/news-items",
+    response_model=list[NewsItemResponse],
+)
+async def get_news_items(
+    episode_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> list[NewsItem]:
+    """Get all news items for an episode."""
+    result = await session.execute(
+        select(NewsItem)
+        .where(NewsItem.episode_id == episode_id)
+        .order_by(NewsItem.id)
+    )
+    return list(result.scalars().all())

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -4,7 +4,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import PipelineStep, StepName, StepStatus
+from app.models import NewsItem, PipelineStep, StepName, StepStatus
 
 
 class TestEpisodesAPI:
@@ -126,6 +126,50 @@ class TestPipelineAPI:
 
         response = await client.post(f"/api/episodes/{episode_id}/steps/invalid/run")
         assert response.status_code == 400
+
+
+class TestNewsItemsAPI:
+    """Tests for NewsItem endpoints."""
+
+    async def test_get_news_items_empty(self, client: AsyncClient):
+        create_response = await client.post("/api/episodes", json={"title": "News Test"})
+        episode_id = create_response.json()["id"]
+
+        response = await client.get(f"/api/episodes/{episode_id}/news-items")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    async def test_get_news_items_with_data(self, client: AsyncClient, session: AsyncSession):
+        create_response = await client.post("/api/episodes", json={"title": "News Data Test"})
+        episode_id = create_response.json()["id"]
+
+        news = NewsItem(
+            episode_id=episode_id,
+            title="Test News",
+            summary="Test summary",
+            source_url="https://example.com/news/1",
+            source_name="Example News",
+            fact_check_status="verified",
+            fact_check_score=4,
+            fact_check_details="Verified via official sources",
+            reference_urls=["https://example.com/ref1"],
+            analysis_data={"background": "test background", "perspectives": []},
+            script_text="Test script text",
+        )
+        session.add(news)
+        await session.commit()
+
+        response = await client.get(f"/api/episodes/{episode_id}/news-items")
+        assert response.status_code == 200
+        items = response.json()
+        assert len(items) == 1
+        item = items[0]
+        assert item["title"] == "Test News"
+        assert item["fact_check_status"] == "verified"
+        assert item["fact_check_score"] == 4
+        assert item["reference_urls"] == ["https://example.com/ref1"]
+        assert item["analysis_data"]["background"] == "test background"
+        assert item["script_text"] == "Test script text"
 
 
 class TestStatsAPI:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import type {
   Episode,
   EpisodeListResponse,
+  NewsItem,
   PipelineStep,
   CostStatsResponse,
   EpisodeCostResponse,
@@ -18,6 +19,8 @@ export const api = {
     client.post<Episode>("/episodes", { title }),
   getSteps: (episodeId: number) =>
     client.get<PipelineStep[]>(`/episodes/${episodeId}/steps`),
+  getNewsItems: (episodeId: number) =>
+    client.get<NewsItem[]>(`/episodes/${episodeId}/news-items`),
   runStep: (episodeId: number, stepName: string) =>
     client.post<PipelineStep>(`/episodes/${episodeId}/steps/${stepName}/run`),
   approveStep: (stepId: number) =>

--- a/frontend/src/components/ApprovalGate.tsx
+++ b/frontend/src/components/ApprovalGate.tsx
@@ -1,14 +1,16 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { api } from "../api/client";
-import type { PipelineStep } from "../types";
+import type { PipelineStep, NewsItem } from "../types";
+import StepDataRenderer from "./step-renderers/StepDataRenderer";
 
 interface Props {
   step: PipelineStep;
+  newsItems: NewsItem[];
   onUpdated: () => void;
 }
 
-export default function ApprovalGate({ step, onUpdated }: Props) {
+export default function ApprovalGate({ step, newsItems, onUpdated }: Props) {
   const { t } = useTranslation();
   const [rejecting, setRejecting] = useState(false);
   const [reason, setReason] = useState("");
@@ -55,14 +57,21 @@ export default function ApprovalGate({ step, onUpdated }: Props) {
       )}
 
       {step.output_data && (
-        <details className="mb-3">
-          <summary className="cursor-pointer text-sm text-gray-600 hover:text-gray-800">
-            {t("approval.showOutput")}
-          </summary>
-          <pre className="mt-2 p-3 bg-white rounded border text-xs overflow-auto max-h-64">
-            {JSON.stringify(step.output_data, null, 2)}
-          </pre>
-        </details>
+        <div className="mb-3">
+          <StepDataRenderer
+            stepName={step.step_name}
+            outputData={step.output_data}
+            newsItems={newsItems}
+          />
+          <details className="mt-2">
+            <summary className="cursor-pointer text-xs text-gray-400 hover:text-gray-600">
+              {t("pipeline.rawJson")}
+            </summary>
+            <pre className="mt-2 p-3 bg-white rounded border text-xs overflow-auto max-h-64">
+              {JSON.stringify(step.output_data, null, 2)}
+            </pre>
+          </details>
+        </div>
       )}
 
       {!rejecting ? (

--- a/frontend/src/components/EpisodeDetail.tsx
+++ b/frontend/src/components/EpisodeDetail.tsx
@@ -3,15 +3,18 @@ import { Link, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { api } from "../api/client";
 import { useEpisode } from "../hooks/useEpisode";
+import { useNewsItems } from "../hooks/useNewsItems";
 import type { StepName, PipelineStep } from "../types";
 import PipelineView from "./PipelineView";
 import ApprovalGate from "./ApprovalGate";
+import StepDataRenderer from "./step-renderers/StepDataRenderer";
 
 export default function EpisodeDetail() {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const episodeId = Number(id);
   const { episode, loading, error, refetch } = useEpisode(episodeId);
+  const { newsItems } = useNewsItems(episodeId);
   const [selectedStep, setSelectedStep] = useState<StepName | null>(null);
   const [runningStep, setRunningStep] = useState(false);
 
@@ -103,9 +106,27 @@ export default function EpisodeDetail() {
             )}
           </dl>
 
+          {activeStep.output_data && activeStep.status !== "needs_approval" && (
+            <div className="mb-3">
+              <StepDataRenderer
+                stepName={activeStep.step_name}
+                outputData={activeStep.output_data}
+                newsItems={newsItems}
+              />
+              <details className="mt-2">
+                <summary className="cursor-pointer text-xs text-gray-400 hover:text-gray-600">
+                  {t("pipeline.rawJson")}
+                </summary>
+                <pre className="mt-1 p-3 bg-gray-50 rounded border text-xs overflow-auto max-h-48">
+                  {JSON.stringify(activeStep.output_data, null, 2)}
+                </pre>
+              </details>
+            </div>
+          )}
+
           {activeStep.input_data && (
             <details className="mb-2">
-              <summary className="cursor-pointer text-sm text-gray-600 hover:text-gray-800">
+              <summary className="cursor-pointer text-xs text-gray-400 hover:text-gray-600">
                 {t("pipeline.inputData")}
               </summary>
               <pre className="mt-1 p-3 bg-gray-50 rounded border text-xs overflow-auto max-h-48">
@@ -114,18 +135,7 @@ export default function EpisodeDetail() {
             </details>
           )}
 
-          {activeStep.output_data && activeStep.status !== "needs_approval" && (
-            <details>
-              <summary className="cursor-pointer text-sm text-gray-600 hover:text-gray-800">
-                {t("pipeline.outputData")}
-              </summary>
-              <pre className="mt-1 p-3 bg-gray-50 rounded border text-xs overflow-auto max-h-48">
-                {JSON.stringify(activeStep.output_data, null, 2)}
-              </pre>
-            </details>
-          )}
-
-          <ApprovalGate step={activeStep} onUpdated={refetch} />
+          <ApprovalGate step={activeStep} newsItems={newsItems} onUpdated={refetch} />
         </div>
       )}
 

--- a/frontend/src/components/step-renderers/AnalysisRenderer.tsx
+++ b/frontend/src/components/step-renderers/AnalysisRenderer.tsx
@@ -1,0 +1,167 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { NewsItem } from "../../types";
+
+interface Props {
+  newsItems: NewsItem[];
+}
+
+interface AnalysisData {
+  background?: string;
+  perspectives?: Array<{ viewpoint?: string; description?: string }>;
+  data_verification?: string;
+  impact_assessment?: string;
+  severity?: string;
+  topics?: string[];
+}
+
+function SeverityBadge({ severity }: { severity: string }) {
+  const color =
+    severity === "high"
+      ? "bg-red-100 text-red-800"
+      : severity === "medium"
+        ? "bg-yellow-100 text-yellow-800"
+        : "bg-green-100 text-green-800";
+  return (
+    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${color}`}>
+      {severity}
+    </span>
+  );
+}
+
+export default function AnalysisRenderer({ newsItems }: Props) {
+  const { t } = useTranslation();
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  const analyzedItems = newsItems.filter((n) => n.analysis_data);
+  const severityCounts = analyzedItems.reduce(
+    (acc, n) => {
+      const s = (n.analysis_data as AnalysisData)?.severity ?? "low";
+      acc[s] = (acc[s] ?? 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>,
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-3 gap-3">
+        <div className="bg-blue-50 rounded-lg p-3 text-center">
+          <p className="text-2xl font-bold text-blue-700">
+            {analyzedItems.length}
+          </p>
+          <p className="text-xs text-blue-600">
+            {t("stepData.analysis.analyzed")}
+          </p>
+        </div>
+        {Object.entries(severityCounts).map(([severity, count]) => (
+          <div key={severity} className="bg-gray-50 rounded-lg p-3 text-center">
+            <p className="text-2xl font-bold text-gray-700">{count}</p>
+            <p className="text-xs text-gray-600">
+              {t(`stepData.analysis.severity_${severity}`, severity)}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div className="space-y-2">
+        {newsItems.map((item) => {
+          const data = item.analysis_data as AnalysisData | null;
+          return (
+            <div key={item.id} className="border rounded-lg">
+              <button
+                onClick={() =>
+                  setExpandedId(expandedId === item.id ? null : item.id)
+                }
+                className="w-full flex items-center justify-between p-3 text-left hover:bg-gray-50 cursor-pointer"
+              >
+                <span className="text-sm font-medium text-gray-800 truncate mr-2">
+                  {item.title}
+                </span>
+                <div className="flex items-center gap-2 shrink-0">
+                  {data?.severity && (
+                    <SeverityBadge severity={data.severity} />
+                  )}
+                  {data?.topics?.map((topic) => (
+                    <span
+                      key={topic}
+                      className="px-2 py-0.5 rounded-full text-xs bg-blue-50 text-blue-700"
+                    >
+                      {topic}
+                    </span>
+                  ))}
+                  <span className="text-gray-400 text-xs">
+                    {expandedId === item.id ? "▲" : "▼"}
+                  </span>
+                </div>
+              </button>
+
+              {expandedId === item.id && data && (
+                <div className="px-3 pb-3 border-t text-sm space-y-3 mt-0">
+                  {data.background && (
+                    <div className="mt-2">
+                      <p className="text-xs font-medium text-gray-500 mb-1">
+                        {t("stepData.analysis.background")}
+                      </p>
+                      <p className="text-gray-700">{data.background}</p>
+                    </div>
+                  )}
+
+                  {data.perspectives && data.perspectives.length > 0 && (
+                    <div>
+                      <p className="text-xs font-medium text-gray-500 mb-1">
+                        {t("stepData.analysis.perspectives")}
+                      </p>
+                      <table className="w-full text-xs">
+                        <thead>
+                          <tr className="border-b text-gray-500">
+                            <th className="text-left pb-1 font-medium">
+                              {t("stepData.analysis.viewpoint")}
+                            </th>
+                            <th className="text-left pb-1 font-medium">
+                              {t("stepData.analysis.description")}
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {data.perspectives.map((p, i) => (
+                            <tr key={i} className="border-b last:border-0">
+                              <td className="py-1 pr-2 font-medium text-gray-700">
+                                {p.viewpoint}
+                              </td>
+                              <td className="py-1 text-gray-600">
+                                {p.description}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+
+                  {data.data_verification && (
+                    <div>
+                      <p className="text-xs font-medium text-gray-500 mb-1">
+                        {t("stepData.analysis.dataVerification")}
+                      </p>
+                      <p className="text-gray-700">{data.data_verification}</p>
+                    </div>
+                  )}
+
+                  {data.impact_assessment && (
+                    <div>
+                      <p className="text-xs font-medium text-gray-500 mb-1">
+                        {t("stepData.analysis.impact")}
+                      </p>
+                      <p className="text-gray-700">{data.impact_assessment}</p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/step-renderers/CollectionRenderer.tsx
+++ b/frontend/src/components/step-renderers/CollectionRenderer.tsx
@@ -1,0 +1,74 @@
+import { useTranslation } from "react-i18next";
+import type { NewsItem } from "../../types";
+
+interface Props {
+  outputData: Record<string, unknown>;
+  newsItems: NewsItem[];
+}
+
+export default function CollectionRenderer({ outputData, newsItems }: Props) {
+  const { t } = useTranslation();
+
+  const stats = outputData.stats as
+    | { fetched?: number; saved?: number }
+    | undefined;
+
+  return (
+    <div className="space-y-4">
+      {stats && (
+        <div className="grid grid-cols-2 gap-3">
+          <div className="bg-blue-50 rounded-lg p-3 text-center">
+            <p className="text-2xl font-bold text-blue-700">
+              {stats.fetched ?? "-"}
+            </p>
+            <p className="text-xs text-blue-600">
+              {t("stepData.collection.fetched")}
+            </p>
+          </div>
+          <div className="bg-green-50 rounded-lg p-3 text-center">
+            <p className="text-2xl font-bold text-green-700">
+              {stats.saved ?? "-"}
+            </p>
+            <p className="text-xs text-green-600">
+              {t("stepData.collection.saved")}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {newsItems.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-gray-500">
+                <th className="pb-2 font-medium">
+                  {t("stepData.collection.title")}
+                </th>
+                <th className="pb-2 font-medium">
+                  {t("stepData.collection.source")}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {newsItems.map((item) => (
+                <tr key={item.id} className="border-b last:border-0">
+                  <td className="py-2 pr-3">
+                    <a
+                      href={item.source_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:underline"
+                    >
+                      {item.title}
+                    </a>
+                  </td>
+                  <td className="py-2 text-gray-500">{item.source_name}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/step-renderers/FactcheckRenderer.tsx
+++ b/frontend/src/components/step-renderers/FactcheckRenderer.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { NewsItem } from "../../types";
+
+interface Props {
+  newsItems: NewsItem[];
+}
+
+function ScoreBadge({ score }: { score: number | null }) {
+  if (score === null) return null;
+  const color =
+    score >= 4
+      ? "bg-green-100 text-green-800"
+      : score >= 3
+        ? "bg-yellow-100 text-yellow-800"
+        : "bg-red-100 text-red-800";
+  return (
+    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${color}`}>
+      {score}/5
+    </span>
+  );
+}
+
+function StatusBadge({ status }: { status: string | null }) {
+  const { t } = useTranslation();
+  if (!status) return null;
+  const color =
+    status === "verified"
+      ? "bg-green-100 text-green-800"
+      : status === "unverified"
+        ? "bg-red-100 text-red-800"
+        : "bg-gray-100 text-gray-800";
+  return (
+    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${color}`}>
+      {t(`stepData.factcheck.status_${status}`, status)}
+    </span>
+  );
+}
+
+export default function FactcheckRenderer({ newsItems }: Props) {
+  const { t } = useTranslation();
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  const checkedItems = newsItems.filter((n) => n.fact_check_status);
+  const avgScore =
+    checkedItems.length > 0
+      ? (
+          checkedItems.reduce((sum, n) => sum + (n.fact_check_score ?? 0), 0) /
+          checkedItems.length
+        ).toFixed(1)
+      : "-";
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="bg-blue-50 rounded-lg p-3 text-center">
+          <p className="text-2xl font-bold text-blue-700">
+            {checkedItems.length}
+          </p>
+          <p className="text-xs text-blue-600">
+            {t("stepData.factcheck.checked")}
+          </p>
+        </div>
+        <div className="bg-purple-50 rounded-lg p-3 text-center">
+          <p className="text-2xl font-bold text-purple-700">{avgScore}</p>
+          <p className="text-xs text-purple-600">
+            {t("stepData.factcheck.avgScore")}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        {newsItems.map((item) => (
+          <div key={item.id} className="border rounded-lg">
+            <button
+              onClick={() =>
+                setExpandedId(expandedId === item.id ? null : item.id)
+              }
+              className="w-full flex items-center justify-between p-3 text-left hover:bg-gray-50 cursor-pointer"
+            >
+              <span className="text-sm font-medium text-gray-800 truncate mr-2">
+                {item.title}
+              </span>
+              <div className="flex items-center gap-2 shrink-0">
+                <StatusBadge status={item.fact_check_status} />
+                <ScoreBadge score={item.fact_check_score} />
+                <span className="text-gray-400 text-xs">
+                  {expandedId === item.id ? "▲" : "▼"}
+                </span>
+              </div>
+            </button>
+
+            {expandedId === item.id && (
+              <div className="px-3 pb-3 border-t text-sm space-y-2">
+                {item.fact_check_details && (
+                  <p className="text-gray-700 mt-2">
+                    {item.fact_check_details}
+                  </p>
+                )}
+                {item.reference_urls && item.reference_urls.length > 0 && (
+                  <div>
+                    <p className="text-xs font-medium text-gray-500 mb-1">
+                      {t("stepData.factcheck.references")}
+                    </p>
+                    <ul className="space-y-1">
+                      {item.reference_urls.map((url, i) => (
+                        <li key={i}>
+                          <a
+                            href={url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-xs text-blue-600 hover:underline break-all"
+                          >
+                            {url}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/step-renderers/ScriptRenderer.tsx
+++ b/frontend/src/components/step-renderers/ScriptRenderer.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { NewsItem } from "../../types";
+
+interface Props {
+  outputData: Record<string, unknown>;
+  newsItems: NewsItem[];
+}
+
+export default function ScriptRenderer({ outputData, newsItems }: Props) {
+  const { t } = useTranslation();
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  const fullScript = outputData.full_script as string | undefined;
+  const itemsWithScript = newsItems.filter((n) => n.script_text);
+
+  return (
+    <div className="space-y-4">
+      {fullScript && (
+        <div>
+          <h4 className="text-sm font-medium text-gray-600 mb-2">
+            {t("stepData.script.fullScript")}
+          </h4>
+          <div className="bg-gray-50 rounded-lg p-4 text-sm text-gray-800 whitespace-pre-wrap border max-h-96 overflow-y-auto">
+            {fullScript}
+          </div>
+        </div>
+      )}
+
+      {itemsWithScript.length > 0 && (
+        <div>
+          <h4 className="text-sm font-medium text-gray-600 mb-2">
+            {t("stepData.script.perArticle")}
+          </h4>
+          <div className="space-y-2">
+            {itemsWithScript.map((item) => (
+              <div key={item.id} className="border rounded-lg">
+                <button
+                  onClick={() =>
+                    setExpandedId(expandedId === item.id ? null : item.id)
+                  }
+                  className="w-full flex items-center justify-between p-3 text-left hover:bg-gray-50 cursor-pointer"
+                >
+                  <span className="text-sm font-medium text-gray-800 truncate mr-2">
+                    {item.title}
+                  </span>
+                  <span className="text-gray-400 text-xs shrink-0">
+                    {expandedId === item.id ? "▲" : "▼"}
+                  </span>
+                </button>
+                {expandedId === item.id && item.script_text && (
+                  <div className="px-3 pb-3 border-t">
+                    <p className="text-sm text-gray-700 whitespace-pre-wrap mt-2">
+                      {item.script_text}
+                    </p>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/step-renderers/StepDataRenderer.tsx
+++ b/frontend/src/components/step-renderers/StepDataRenderer.tsx
@@ -1,0 +1,36 @@
+import type { StepName, NewsItem } from "../../types";
+import CollectionRenderer from "./CollectionRenderer";
+import FactcheckRenderer from "./FactcheckRenderer";
+import AnalysisRenderer from "./AnalysisRenderer";
+import ScriptRenderer from "./ScriptRenderer";
+
+interface Props {
+  stepName: StepName;
+  outputData: Record<string, unknown>;
+  newsItems: NewsItem[];
+}
+
+export default function StepDataRenderer({
+  stepName,
+  outputData,
+  newsItems,
+}: Props) {
+  switch (stepName) {
+    case "collection":
+      return (
+        <CollectionRenderer outputData={outputData} newsItems={newsItems} />
+      );
+    case "factcheck":
+      return <FactcheckRenderer newsItems={newsItems} />;
+    case "analysis":
+      return <AnalysisRenderer newsItems={newsItems} />;
+    case "script":
+      return <ScriptRenderer outputData={outputData} newsItems={newsItems} />;
+    default:
+      return (
+        <pre className="p-3 bg-gray-50 rounded border text-xs overflow-auto max-h-64">
+          {JSON.stringify(outputData, null, 2)}
+        </pre>
+      );
+  }
+}

--- a/frontend/src/hooks/useNewsItems.ts
+++ b/frontend/src/hooks/useNewsItems.ts
@@ -1,0 +1,26 @@
+import { useCallback, useEffect, useState } from "react";
+import { api } from "../api/client";
+import type { NewsItem } from "../types";
+
+export function useNewsItems(episodeId: number) {
+  const [newsItems, setNewsItems] = useState<NewsItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetch = useCallback(async () => {
+    try {
+      const res = await api.getNewsItems(episodeId);
+      setNewsItems(res.data);
+    } catch {
+      // silently fail — news items are supplementary
+    } finally {
+      setLoading(false);
+    }
+  }, [episodeId]);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch();
+  }, [fetch]);
+
+  return { newsItems, loading, refetch: fetch };
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -51,7 +51,8 @@
   },
   "pipeline": {
     "inputData": "Input Data",
-    "outputData": "Output Data"
+    "outputData": "Output Data",
+    "rawJson": "Raw JSON"
   },
   "steps": {
     "collection": "Collection",
@@ -90,6 +91,38 @@
     "noData": "No API usage records yet.",
     "loading": "Loading...",
     "fetchFailed": "Failed to fetch cost stats"
+  },
+  "stepData": {
+    "collection": {
+      "fetched": "Fetched",
+      "saved": "Saved",
+      "title": "Title",
+      "source": "Source"
+    },
+    "factcheck": {
+      "checked": "Checked",
+      "avgScore": "Avg Score",
+      "references": "Reference URLs",
+      "status_verified": "Verified",
+      "status_unverified": "Unverified",
+      "status_partially_verified": "Partially Verified"
+    },
+    "analysis": {
+      "analyzed": "Analyzed",
+      "severity_high": "High",
+      "severity_medium": "Medium",
+      "severity_low": "Low",
+      "background": "Background",
+      "perspectives": "Perspectives",
+      "viewpoint": "Viewpoint",
+      "description": "Description",
+      "dataVerification": "Data Verification",
+      "impact": "Impact Assessment"
+    },
+    "script": {
+      "fullScript": "Full Episode Script",
+      "perArticle": "Per-Article Scripts"
+    }
   },
   "errors": {
     "fetchEpisodes": "Failed to fetch episodes",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -51,7 +51,8 @@
   },
   "pipeline": {
     "inputData": "入力データ",
-    "outputData": "出力データ"
+    "outputData": "出力データ",
+    "rawJson": "Raw JSON"
   },
   "steps": {
     "collection": "収集",
@@ -90,6 +91,38 @@
     "noData": "まだAPIの使用記録がありません。",
     "loading": "読み込み中...",
     "fetchFailed": "コスト統計の取得に失敗しました"
+  },
+  "stepData": {
+    "collection": {
+      "fetched": "取得記事数",
+      "saved": "保存記事数",
+      "title": "タイトル",
+      "source": "ソース"
+    },
+    "factcheck": {
+      "checked": "チェック数",
+      "avgScore": "平均スコア",
+      "references": "参考URL",
+      "status_verified": "検証済",
+      "status_unverified": "未検証",
+      "status_partially_verified": "一部検証"
+    },
+    "analysis": {
+      "analyzed": "分析数",
+      "severity_high": "高",
+      "severity_medium": "中",
+      "severity_low": "低",
+      "background": "背景",
+      "perspectives": "複数視点",
+      "viewpoint": "立場",
+      "description": "説明",
+      "dataVerification": "データ検証",
+      "impact": "影響評価"
+    },
+    "script": {
+      "fullScript": "エピソード全体台本",
+      "perArticle": "記事別台本"
+    }
   },
   "errors": {
     "fetchEpisodes": "エピソード一覧の取得に失敗しました",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -40,6 +40,22 @@ export interface Episode {
   pipeline_steps: PipelineStep[];
 }
 
+export interface NewsItem {
+  id: number;
+  episode_id: number;
+  title: string;
+  summary: string | null;
+  source_url: string;
+  source_name: string;
+  fact_check_status: string | null;
+  fact_check_score: number | null;
+  fact_check_details: string | null;
+  reference_urls: string[] | null;
+  analysis_data: Record<string, unknown> | null;
+  script_text: string | null;
+  created_at: string;
+}
+
 export interface EpisodeListResponse {
   episodes: Episode[];
   total: number;


### PR DESCRIPTION
## Summary

- StepResponseに`input_data`/`output_data`/`created_at`を追加し、フロントで実データを取得可能に
- `GET /api/episodes/{id}/news-items` エンドポイント新設（ファクトチェック・分析・台本データ取得）
- ステップ別構造化レンダラー（収集・ファクトチェック・分析・台本）を実装し、承認ゲート含む全表示箇所に統合
- Raw JSONは折りたたみで残存し、デバッグ用途にも対応

## Test plan

- [x] `cd backend && python -m pytest tests/ -v` — 全86テスト通過
- [x] `cd frontend && npx tsc --noEmit` — 型チェック通過
- [x] ブラウザ: エピソード詳細 → 各ステップで構造化表示確認
- [x] 承認ゲートで構造化データ表示 → 承認/却下操作確認

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)