### PR TITLE
feat: 記事POST APIからエピソード作成

### DIFF
--- a/backend/app/api/episodes.py
+++ b/backend/app/api/episodes.py
@@ -24,6 +24,22 @@ class EpisodeCreate(BaseModel):
     title: str
 
 
+class ArticleInput(BaseModel):
+    """A single article for direct episode creation."""
+
+    title: str
+    summary: str | None = None
+    source_url: str
+    source_name: str
+
+
+class EpisodeFromArticles(BaseModel):
+    """Request body for creating an episode from pre-supplied articles."""
+
+    title: str
+    articles: list[ArticleInput]
+
+
 class StepResponse(BaseModel):
     """Pipeline step in episode response."""
 
@@ -94,6 +110,20 @@ async def create_episode(
 ) -> Episode:
     """Create a new episode with all 7 pipeline steps."""
     episode = await engine.create_episode(body.title, session)
+    return await engine.get_episode_with_steps(episode.id, session)
+
+
+@router.post("/episodes/from-articles", response_model=EpisodeResponse, status_code=201)
+async def create_episode_from_articles(
+    body: EpisodeFromArticles,
+    session: AsyncSession = Depends(get_session),
+) -> Episode:
+    """Create an episode from pre-supplied articles (skips collection step)."""
+    if not body.articles:
+        raise HTTPException(status_code=400, detail="At least one article is required")
+
+    articles = [a.model_dump() for a in body.articles]
+    episode = await engine.create_episode_from_articles(body.title, articles, session)
     return await engine.get_episode_with_steps(episode.id, session)
 
 

--- a/backend/app/pipeline/engine.py
+++ b/backend/app/pipeline/engine.py
@@ -43,6 +43,65 @@ class PipelineEngine:
         await session.refresh(episode)
         return episode
 
+    async def create_episode_from_articles(
+        self,
+        title: str,
+        articles: list[dict],
+        session: AsyncSession,
+    ) -> Episode:
+        """Create an episode from pre-supplied articles, skipping the collection step.
+
+        The collection step is auto-approved with the articles as output_data.
+        """
+        from app.models import NewsItem
+
+        episode = Episode(title=title, status=EpisodeStatus.IN_PROGRESS)
+        session.add(episode)
+        await session.flush()
+
+        # Create all 7 pipeline steps
+        steps = {}
+        for step_value in STEP_ORDER:
+            step = PipelineStep(
+                episode_id=episode.id,
+                step_name=StepName(step_value),
+                status=StepStatus.PENDING,
+            )
+            session.add(step)
+            steps[step_value] = step
+
+        await session.flush()
+
+        # Create NewsItems from articles
+        for article in articles:
+            item = NewsItem(
+                episode_id=episode.id,
+                title=article["title"],
+                summary=article.get("summary"),
+                source_url=article["source_url"],
+                source_name=article["source_name"],
+            )
+            session.add(item)
+
+        # Auto-approve collection step
+        collection_step = steps["collection"]
+        collection_step.status = StepStatus.APPROVED
+        collection_step.started_at = datetime.now(UTC)
+        collection_step.completed_at = datetime.now(UTC)
+        collection_step.approved_at = datetime.now(UTC)
+        collection_step.output_data = {
+            "source": "api",
+            "articles_count": len(articles),
+            "articles": [
+                {"title": a["title"], "source_name": a["source_name"], "source_url": a["source_url"]}
+                for a in articles
+            ],
+        }
+
+        await session.commit()
+        await session.refresh(episode)
+        return episode
+
     async def run_step(self, episode_id: int, step_name: StepName, session: AsyncSession) -> None:
         """Execute a specific pipeline step."""
         # Verify step is registered

--- a/backend/tests/test_from_articles.py
+++ b/backend/tests/test_from_articles.py
@@ -1,0 +1,114 @@
+"""Tests for the from-articles episode creation API."""
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Episode, NewsItem, PipelineStep, StepName, StepStatus
+
+
+SAMPLE_ARTICLES = [
+    {
+        "title": "テスト記事1",
+        "summary": "テスト要約1",
+        "source_url": "https://example.com/1",
+        "source_name": "TestSource",
+    },
+    {
+        "title": "テスト記事2",
+        "summary": "テスト要約2",
+        "source_url": "https://example.com/2",
+        "source_name": "TestSource",
+    },
+]
+
+
+class TestFromArticlesAPI:
+    async def test_create_episode_from_articles(self, client: AsyncClient):
+        response = await client.post(
+            "/api/episodes/from-articles",
+            json={"title": "テストエピソード", "articles": SAMPLE_ARTICLES},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == "テストエピソード"
+        assert data["status"] == "in_progress"
+
+    async def test_collection_step_auto_approved(self, client: AsyncClient, session: AsyncSession):
+        response = await client.post(
+            "/api/episodes/from-articles",
+            json={"title": "テスト", "articles": SAMPLE_ARTICLES},
+        )
+        episode_id = response.json()["id"]
+
+        result = await session.execute(
+            select(PipelineStep).where(
+                PipelineStep.episode_id == episode_id,
+                PipelineStep.step_name == StepName.COLLECTION,
+            )
+        )
+        step = result.scalar_one()
+        assert step.status == StepStatus.APPROVED
+        assert step.output_data["source"] == "api"
+        assert step.output_data["articles_count"] == 2
+
+    async def test_news_items_created(self, client: AsyncClient, session: AsyncSession):
+        response = await client.post(
+            "/api/episodes/from-articles",
+            json={"title": "テスト", "articles": SAMPLE_ARTICLES},
+        )
+        episode_id = response.json()["id"]
+
+        result = await session.execute(
+            select(NewsItem).where(NewsItem.episode_id == episode_id).order_by(NewsItem.id)
+        )
+        items = list(result.scalars().all())
+        assert len(items) == 2
+        assert items[0].title == "テスト記事1"
+        assert items[1].source_url == "https://example.com/2"
+
+    async def test_factcheck_step_is_pending(self, client: AsyncClient, session: AsyncSession):
+        response = await client.post(
+            "/api/episodes/from-articles",
+            json={"title": "テスト", "articles": SAMPLE_ARTICLES},
+        )
+        episode_id = response.json()["id"]
+
+        result = await session.execute(
+            select(PipelineStep).where(
+                PipelineStep.episode_id == episode_id,
+                PipelineStep.step_name == StepName.FACTCHECK,
+            )
+        )
+        step = result.scalar_one()
+        assert step.status == StepStatus.PENDING
+
+    async def test_empty_articles_returns_400(self, client: AsyncClient):
+        response = await client.post(
+            "/api/episodes/from-articles",
+            json={"title": "テスト", "articles": []},
+        )
+        assert response.status_code == 400
+
+    async def test_article_without_summary(self, client: AsyncClient, session: AsyncSession):
+        response = await client.post(
+            "/api/episodes/from-articles",
+            json={
+                "title": "テスト",
+                "articles": [
+                    {
+                        "title": "タイトルのみ",
+                        "source_url": "https://example.com/3",
+                        "source_name": "TestSource",
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 201
+        episode_id = response.json()["id"]
+
+        result = await session.execute(
+            select(NewsItem).where(NewsItem.episode_id == episode_id)
+        )
+        item = result.scalar_one()
+        assert item.summary is None


### PR DESCRIPTION
## Summary
- `POST /api/episodes/from-articles` で記事を直接投入してエピソード作成
- collection ステップを自動承認、factcheck 以降を通常通り実行可能
- スクレイピング不要で任意の記事からラジオ生成

Closes #16

## API

```json
POST /api/episodes/from-articles
{
  "title": "エピソードタイトル",
  "articles": [
    {"title": "記事タイトル", "summary": "要約", "source_url": "https://...", "source_name": "ソース名"}
  ]
}
```

## Test plan
- [x] `pytest tests/test_from_articles.py` — 全6テスト通過
- [x] collection ステップ自動承認確認
- [x] 空記事で400エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)