### PR TITLE
feat: ElevenLabs/Google Cloud TTS プロバイダー追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,10 +29,15 @@ COLLECTION_QUERIES=熊本 ニュース,熊本県 政治,熊本 経済
 # Media
 MEDIA_DIR=/app/media
 
-# Voice/TTS
+# Voice/TTS (voicevox, openai, elevenlabs, google)
 PIPELINE_VOICE_PROVIDER=voicevox
 OPENAI_TTS_MODEL=tts-1
 OPENAI_TTS_VOICE=alloy
+ELEVENLABS_API_KEY=
+ELEVENLABS_VOICE_ID=21m00Tcm4TlvDq8ikWAM
+ELEVENLABS_MODEL_ID=eleven_multilingual_v2
+GOOGLE_TTS_VOICE=ja-JP-Neural2-B
+GOOGLE_TTS_LANGUAGE_CODE=ja-JP
 
 # VOICEVOX
 VOICEVOX_HOST=http://voicevox:50021

--- a/backend/alembic/versions/005_add_tts_pricing.py
+++ b/backend/alembic/versions/005_add_tts_pricing.py
@@ -1,0 +1,62 @@
+"""Add TTS provider pricing data
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-03-09
+
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "005"
+down_revision: str | None = "004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# TTS pricing (per 1M characters, approximated as input tokens for cost tracking)
+TTS_PRICING = [
+    # ElevenLabs (standard voices ~$0.30/1K = $300/1M chars)
+    ("elevenlabs-v2", "elevenlabs", 300.00, 0.0),
+    ("elevenlabs-turbo", "elevenlabs", 150.00, 0.0),
+    # Google Cloud TTS
+    ("google-tts-standard", "google", 4.00, 0.0),
+    ("google-tts-wavenet", "google", 16.00, 0.0),
+    ("google-tts-neural2", "google", 16.00, 0.0),
+    ("google-tts-journey", "google", 30.00, 0.0),
+    # OpenAI TTS (already in 004, but add gpt-4o-mini-tts)
+    ("gpt-4o-mini-tts", "openai", 0.60, 12.00),
+]
+
+
+def upgrade() -> None:
+    from sqlalchemy import table, column, String, Float
+
+    model_pricing = table(
+        "model_pricing",
+        column("model_prefix", String),
+        column("provider", String),
+        column("input_price_per_1m", Float),
+        column("output_price_per_1m", Float),
+    )
+
+    op.bulk_insert(
+        model_pricing,
+        [
+            {
+                "model_prefix": prefix,
+                "provider": provider,
+                "input_price_per_1m": input_price,
+                "output_price_per_1m": output_price,
+            }
+            for prefix, provider, input_price, output_price in TTS_PRICING
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DELETE FROM model_pricing WHERE provider = 'elevenlabs' "
+        "OR model_prefix IN ('google-tts-standard', 'google-tts-wavenet', "
+        "'google-tts-neural2', 'google-tts-journey', 'gpt-4o-mini-tts')"
+    )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -36,9 +36,14 @@ class Settings(BaseSettings):
     media_dir: str = "/app/media"
 
     # Voice/TTS
-    pipeline_voice_provider: str = "voicevox"  # "voicevox" or "openai"
+    pipeline_voice_provider: str = "voicevox"  # "voicevox", "openai", "elevenlabs", "google"
     openai_tts_model: str = "tts-1"
     openai_tts_voice: str = "alloy"
+    elevenlabs_api_key: str = ""
+    elevenlabs_voice_id: str = "21m00Tcm4TlvDq8ikWAM"  # Rachel (default)
+    elevenlabs_model_id: str = "eleven_multilingual_v2"
+    google_tts_voice: str = "ja-JP-Neural2-B"  # Japanese male
+    google_tts_language_code: str = "ja-JP"
 
     # VOICEVOX
     voicevox_host: str = "http://voicevox:50021"

--- a/backend/app/services/tts_elevenlabs.py
+++ b/backend/app/services/tts_elevenlabs.py
@@ -1,0 +1,84 @@
+"""ElevenLabs TTS provider implementation."""
+
+import logging
+
+import httpx
+
+from app.config import settings
+from app.services.tts_openai import concatenate_mp3, split_text_chunks
+from app.services.tts_provider import TTSProvider
+
+logger = logging.getLogger(__name__)
+
+ELEVENLABS_API_URL = "https://api.elevenlabs.io/v1"
+
+# ElevenLabs has a ~5000 character limit per request
+MAX_CHARS_PER_CHUNK = 5000
+
+
+class ElevenLabsTTSProvider(TTSProvider):
+    """TTS provider using ElevenLabs API.
+
+    Pricing (2026):
+    - Standard voices: ~$0.30/1K chars ($300/1M chars)
+    - Turbo models: ~$0.15/1K chars ($150/1M chars)
+    - Free tier: 10K chars/month
+    """
+
+    @property
+    def audio_format(self) -> str:
+        return "mp3"
+
+    async def synthesize(self, text: str) -> bytes:
+        """Synthesize text to MP3 audio using ElevenLabs.
+
+        Splits long text into chunks and concatenates results.
+        """
+        text_chunks = split_text_chunks(text, max_chars=MAX_CHARS_PER_CHUNK)
+        if not text_chunks:
+            raise ValueError("Empty text provided for synthesis")
+
+        audio_chunks: list[bytes] = []
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            for chunk in text_chunks:
+                audio = await self._synthesize_chunk(client, chunk)
+                audio_chunks.append(audio)
+
+        return concatenate_mp3(audio_chunks)
+
+    async def _synthesize_chunk(self, client: httpx.AsyncClient, text: str) -> bytes:
+        """Synthesize a single chunk via ElevenLabs API."""
+        url = f"{ELEVENLABS_API_URL}/text-to-speech/{settings.elevenlabs_voice_id}"
+
+        response = await client.post(
+            url,
+            headers={
+                "xi-api-key": settings.elevenlabs_api_key,
+                "Content-Type": "application/json",
+                "Accept": "audio/mpeg",
+            },
+            json={
+                "text": text,
+                "model_id": settings.elevenlabs_model_id,
+                "voice_settings": {
+                    "stability": 0.5,
+                    "similarity_boost": 0.75,
+                },
+            },
+        )
+        response.raise_for_status()
+
+        logger.debug("ElevenLabs synthesized: %d chars -> %d bytes", len(text), len(response.content))
+        return response.content
+
+    async def health_check(self) -> bool:
+        """Check if ElevenLabs API is accessible."""
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(
+                    f"{ELEVENLABS_API_URL}/user",
+                    headers={"xi-api-key": settings.elevenlabs_api_key},
+                )
+                return response.status_code == 200
+        except httpx.HTTPError:
+            return False

--- a/backend/app/services/tts_google.py
+++ b/backend/app/services/tts_google.py
@@ -1,0 +1,97 @@
+"""Google Cloud Text-to-Speech provider implementation."""
+
+import logging
+
+import httpx
+
+from app.config import settings
+from app.services.tts_provider import TTSProvider
+from app.services.tts_voicevox import concatenate_wav, split_sentences
+
+logger = logging.getLogger(__name__)
+
+GOOGLE_TTS_API_URL = "https://texttospeech.googleapis.com/v1/text:synthesize"
+
+# Google TTS has a 5000 byte limit per request (~2500 Japanese chars)
+MAX_CHARS_PER_CHUNK = 2500
+
+
+class GoogleTTSProvider(TTSProvider):
+    """TTS provider using Google Cloud Text-to-Speech API.
+
+    Pricing (2026):
+    - Standard voices: $4/1M chars (free tier: 4M chars/month)
+    - WaveNet voices: $16/1M chars (free tier: 1M chars/month)
+    - Neural2 voices: $16/1M chars (free tier: 1M chars/month)
+    - Journey voices: $30/1M chars
+    """
+
+    @property
+    def audio_format(self) -> str:
+        return "wav"
+
+    async def synthesize(self, text: str) -> bytes:
+        """Synthesize text to WAV audio using Google Cloud TTS.
+
+        Splits long text into sentences and synthesizes each separately.
+        """
+        sentences = split_sentences(text)
+        if not sentences:
+            raise ValueError("Empty text provided for synthesis")
+
+        # Group sentences into chunks within limit
+        chunks: list[str] = []
+        current = ""
+        for sentence in sentences:
+            if len(current) + len(sentence) > MAX_CHARS_PER_CHUNK and current:
+                chunks.append(current)
+                current = sentence
+            else:
+                current += sentence
+        if current:
+            chunks.append(current)
+
+        audio_chunks: list[bytes] = []
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            for chunk in chunks:
+                audio = await self._synthesize_chunk(client, chunk)
+                audio_chunks.append(audio)
+
+        return concatenate_wav(audio_chunks)
+
+    async def _synthesize_chunk(self, client: httpx.AsyncClient, text: str) -> bytes:
+        """Synthesize a single chunk via Google Cloud TTS API."""
+        response = await client.post(
+            GOOGLE_TTS_API_URL,
+            params={"key": settings.google_api_key},
+            json={
+                "input": {"text": text},
+                "voice": {
+                    "languageCode": settings.google_tts_language_code,
+                    "name": settings.google_tts_voice,
+                },
+                "audioConfig": {
+                    "audioEncoding": "LINEAR16",
+                    "sampleRateHertz": 24000,
+                },
+            },
+        )
+        response.raise_for_status()
+
+        import base64
+
+        audio_content = base64.b64decode(response.json()["audioContent"])
+        logger.debug("Google TTS synthesized: %d chars -> %d bytes", len(text), len(audio_content))
+        return audio_content
+
+    async def health_check(self) -> bool:
+        """Check if Google Cloud TTS API is accessible."""
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(
+                    "https://texttospeech.googleapis.com/v1/voices",
+                    params={"key": settings.google_api_key},
+                )
+                return response.status_code == 200
+        except httpx.HTTPError:
+            return False

--- a/backend/app/services/tts_provider.py
+++ b/backend/app/services/tts_provider.py
@@ -40,5 +40,13 @@ def get_tts_provider() -> TTSProvider:
         from app.services.tts_openai import OpenAITTSProvider
 
         return OpenAITTSProvider()
+    elif provider_name == "elevenlabs":
+        from app.services.tts_elevenlabs import ElevenLabsTTSProvider
+
+        return ElevenLabsTTSProvider()
+    elif provider_name == "google":
+        from app.services.tts_google import GoogleTTSProvider
+
+        return GoogleTTSProvider()
     else:
         raise ValueError(f"Unknown TTS provider: {provider_name}")

--- a/backend/tests/test_tts_external.py
+++ b/backend/tests/test_tts_external.py
@@ -1,0 +1,131 @@
+"""Tests for external TTS providers (ElevenLabs, Google Cloud TTS)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.tts_elevenlabs import ElevenLabsTTSProvider
+from app.services.tts_google import GoogleTTSProvider
+
+
+class TestElevenLabsTTSProvider:
+    def test_audio_format(self):
+        provider = ElevenLabsTTSProvider()
+        assert provider.audio_format == "mp3"
+
+    @patch("app.services.tts_elevenlabs.settings")
+    async def test_synthesize(self, mock_settings):
+        mock_settings.elevenlabs_api_key = "test-key"
+        mock_settings.elevenlabs_voice_id = "test-voice"
+        mock_settings.elevenlabs_model_id = "eleven_multilingual_v2"
+
+        provider = ElevenLabsTTSProvider()
+
+        with patch("app.services.tts_elevenlabs.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_response = MagicMock()
+            mock_response.content = b"fake-mp3-data"
+            mock_response.raise_for_status = MagicMock()
+            mock_client.post.return_value = mock_response
+
+            result = await provider.synthesize("テスト音声です。")
+
+            assert result == b"fake-mp3-data"
+            mock_client.post.assert_called_once()
+            # Verify API URL contains voice ID
+            call_args = mock_client.post.call_args
+            assert "test-voice" in call_args[0][0]
+
+    async def test_synthesize_empty_raises(self):
+        provider = ElevenLabsTTSProvider()
+        with pytest.raises(ValueError, match="Empty text"):
+            await provider.synthesize("")
+
+    @patch("app.services.tts_elevenlabs.settings")
+    async def test_health_check(self, mock_settings):
+        mock_settings.elevenlabs_api_key = "test-key"
+
+        provider = ElevenLabsTTSProvider()
+
+        with patch("app.services.tts_elevenlabs.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_client.get.return_value = mock_response
+
+            assert await provider.health_check() is True
+
+
+class TestGoogleTTSProvider:
+    def test_audio_format(self):
+        provider = GoogleTTSProvider()
+        assert provider.audio_format == "wav"
+
+    @patch("app.services.tts_google.settings")
+    async def test_synthesize(self, mock_settings):
+        mock_settings.google_api_key = "test-key"
+        mock_settings.google_tts_voice = "ja-JP-Neural2-B"
+        mock_settings.google_tts_language_code = "ja-JP"
+
+        provider = GoogleTTSProvider()
+
+        import base64
+
+        # Google TTS returns base64-encoded LINEAR16 WAV
+        # Create a minimal valid WAV for testing
+        import io
+        import wave
+
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(24000)
+            w.writeframes(b"\x00\x00" * 100)
+        wav_bytes = buf.getvalue()
+        b64_audio = base64.b64encode(wav_bytes).decode()
+
+        with patch("app.services.tts_google.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"audioContent": b64_audio}
+            mock_response.raise_for_status = MagicMock()
+            mock_client.post.return_value = mock_response
+
+            result = await provider.synthesize("テスト。")
+
+            assert len(result) > 0
+            mock_client.post.assert_called_once()
+
+    async def test_synthesize_empty_raises(self):
+        provider = GoogleTTSProvider()
+        with pytest.raises(ValueError, match="Empty text"):
+            await provider.synthesize("")
+
+
+class TestGetTTSProviderExtended:
+    @patch("app.services.tts_provider.settings")
+    def test_elevenlabs_provider(self, mock_settings):
+        mock_settings.pipeline_voice_provider = "elevenlabs"
+        mock_settings.elevenlabs_api_key = "test"
+        from app.services.tts_provider import get_tts_provider
+
+        provider = get_tts_provider()
+        assert isinstance(provider, ElevenLabsTTSProvider)
+
+    @patch("app.services.tts_provider.settings")
+    def test_google_provider(self, mock_settings):
+        mock_settings.pipeline_voice_provider = "google"
+        from app.services.tts_provider import get_tts_provider
+
+        provider = get_tts_provider()
+        assert isinstance(provider, GoogleTTSProvider)


### PR DESCRIPTION
## Summary
- **ElevenLabsTTSProvider**: 高品質多言語音声合成（eleven_multilingual_v2）
- **GoogleTTSProvider**: Neural2/WaveNet日本語対応（LINEAR16 WAV出力）
- `PIPELINE_VOICE_PROVIDER` で4つから選択: `voicevox` / `openai` / `elevenlabs` / `google`
- 料金テーブルにTTS料金データ追加（Alembic 005）

## 料金比較（per 1M chars）

| プロバイダー | 料金 | 品質 | 速度 |
|-------------|------|------|------|
| VOICEVOX | 無料 | 良 | 遅い（CPU） |
| Google Standard | $4 | 普通 | 速い |
| OpenAI tts-1 | $15 | 良 | 速い |
| Google Neural2 | $16 | 良 | 速い |
| ElevenLabs v2 | $300 | 最高 | 速い |

Closes #26

## Test plan
- [x] `pytest tests/test_tts_external.py tests/test_tts_providers.py` — 全30テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)