### PR TITLE
fix: TTS全プロバイダーのコスト記録 + Google TTS byte制限対応

### DIFF
--- a/backend/app/pipeline/voice.py
+++ b/backend/app/pipeline/voice.py
@@ -58,14 +58,21 @@ class VoiceStep(BaseStep):
             episode.audio_path = relative_path
             await session.commit()
 
-        # Record usage for OpenAI TTS
-        if settings.pipeline_voice_provider == "openai":
+        # Record usage for TTS (input_tokens = character count for TTS pricing)
+        provider_name = settings.pipeline_voice_provider
+        if provider_name != "voicevox":  # VOICEVOX is free/local
+            model_map = {
+                "openai": settings.openai_tts_model,
+                "elevenlabs": f"elevenlabs-{settings.elevenlabs_model_id.split('_')[-1]}",
+                "google": f"google-tts-{settings.google_tts_voice.split('-')[-1].lower()}",
+            }
+            model_name = model_map.get(provider_name, provider_name)
             async with async_session() as session:
                 await self.record_usage(
                     session=session,
                     episode_id=episode_id,
-                    provider="openai",
-                    model=settings.openai_tts_model,
+                    provider=provider_name,
+                    model=model_name,
                     input_tokens=len(episode_script),
                     output_tokens=0,
                 )

--- a/backend/app/services/tts_google.py
+++ b/backend/app/services/tts_google.py
@@ -12,8 +12,9 @@ logger = logging.getLogger(__name__)
 
 GOOGLE_TTS_API_URL = "https://texttospeech.googleapis.com/v1/text:synthesize"
 
-# Google TTS has a 5000 byte limit per request (~2500 Japanese chars)
-MAX_CHARS_PER_CHUNK = 2500
+# Google TTS has a 5000 byte limit per request
+# Japanese chars are 3 bytes in UTF-8, so ~1600 chars max
+MAX_BYTES_PER_CHUNK = 4800
 
 
 class GoogleTTSProvider(TTSProvider):
@@ -39,15 +40,16 @@ class GoogleTTSProvider(TTSProvider):
         if not sentences:
             raise ValueError("Empty text provided for synthesis")
 
-        # Group sentences into chunks within limit
+        # Group sentences into chunks within byte limit
         chunks: list[str] = []
         current = ""
         for sentence in sentences:
-            if len(current) + len(sentence) > MAX_CHARS_PER_CHUNK and current:
+            candidate = current + sentence
+            if len(candidate.encode("utf-8")) > MAX_BYTES_PER_CHUNK and current:
                 chunks.append(current)
                 current = sentence
             else:
-                current += sentence
+                current = candidate
         if current:
             chunks.append(current)
 
@@ -76,7 +78,9 @@ class GoogleTTSProvider(TTSProvider):
                 },
             },
         )
-        response.raise_for_status()
+        if response.status_code != 200:
+            logger.error("Google TTS error %d: %s", response.status_code, response.text[:500])
+            response.raise_for_status()
 
         import base64
 


### PR DESCRIPTION
## Summary
- VoiceStep: OpenAI以外のTTSプロバイダー（Google, ElevenLabs）もコスト記録するよう修正
- Google TTS: 5000バイト制限に対応（日本語UTF-8は1文字3バイト）
- Google TTS Neural2-Bで12.9分の音声生成を実機確認済み

## Test plan
- [x] Google TTS で音声生成成功（Episode #1、12.9分）
- [x] `/media/1/audio.wav` でダウンロード確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)