### PR TITLE
feat(ui): ダッシュボード拡張・設定画面・コスト期間フィルタ

### DIFF
--- a/backend/app/api/stats.py
+++ b/backend/app/api/stats.py
@@ -1,6 +1,8 @@
 """Cost statistics API endpoints."""
 
-from fastapi import APIRouter, Depends
+from datetime import date, datetime, time
+
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -55,21 +57,34 @@ class EpisodeCostResponse(BaseModel):
 # --- Endpoints ---
 
 
+def _apply_date_filter(query, from_date: date | None, to_date: date | None):
+    """Apply date range filter to a query."""
+    if from_date:
+        query = query.where(ApiUsage.created_at >= datetime.combine(from_date, time.min))
+    if to_date:
+        query = query.where(ApiUsage.created_at <= datetime.combine(to_date, time.max))
+    return query
+
+
 @router.get("/stats/costs", response_model=CostStatsResponse)
 async def get_cost_stats(
+    from_date: date | None = Query(None, alias="from"),
+    to_date: date | None = Query(None, alias="to"),
     session: AsyncSession = Depends(get_session),
 ) -> dict:
-    """Get overall cost statistics grouped by provider and step."""
+    """Get overall cost statistics grouped by provider and step.
+
+    Optional date range filter: ?from=2026-03-01&to=2026-03-31
+    """
     # By provider
-    provider_result = await session.execute(
-        select(
-            ApiUsage.provider,
-            func.sum(ApiUsage.input_tokens).label("total_input_tokens"),
-            func.sum(ApiUsage.output_tokens).label("total_output_tokens"),
-            func.sum(ApiUsage.cost_usd).label("total_cost_usd"),
-            func.count().label("request_count"),
-        ).group_by(ApiUsage.provider)
-    )
+    provider_query = select(
+        ApiUsage.provider,
+        func.sum(ApiUsage.input_tokens).label("total_input_tokens"),
+        func.sum(ApiUsage.output_tokens).label("total_output_tokens"),
+        func.sum(ApiUsage.cost_usd).label("total_cost_usd"),
+        func.count().label("request_count"),
+    ).group_by(ApiUsage.provider)
+    provider_result = await session.execute(_apply_date_filter(provider_query, from_date, to_date))
     by_provider = [
         CostByProvider(
             provider=row.provider,
@@ -82,15 +97,14 @@ async def get_cost_stats(
     ]
 
     # By step
-    step_result = await session.execute(
-        select(
-            ApiUsage.step_name,
-            func.sum(ApiUsage.input_tokens).label("total_input_tokens"),
-            func.sum(ApiUsage.output_tokens).label("total_output_tokens"),
-            func.sum(ApiUsage.cost_usd).label("total_cost_usd"),
-            func.count().label("request_count"),
-        ).group_by(ApiUsage.step_name)
-    )
+    step_query = select(
+        ApiUsage.step_name,
+        func.sum(ApiUsage.input_tokens).label("total_input_tokens"),
+        func.sum(ApiUsage.output_tokens).label("total_output_tokens"),
+        func.sum(ApiUsage.cost_usd).label("total_cost_usd"),
+        func.count().label("request_count"),
+    ).group_by(ApiUsage.step_name)
+    step_result = await session.execute(_apply_date_filter(step_query, from_date, to_date))
     by_step = [
         CostByStep(
             step_name=row.step_name,
@@ -103,12 +117,11 @@ async def get_cost_stats(
     ]
 
     # Totals
-    total_result = await session.execute(
-        select(
-            func.sum(ApiUsage.cost_usd).label("total_cost"),
-            func.count().label("total_requests"),
-        )
+    total_query = select(
+        func.sum(ApiUsage.cost_usd).label("total_cost"),
+        func.count().label("total_requests"),
     )
+    total_result = await session.execute(_apply_date_filter(total_query, from_date, to_date))
     totals = total_result.one()
 
     return {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import Dashboard from "./components/Dashboard";
 import EpisodeDetail from "./components/EpisodeDetail";
 import CostDashboard from "./components/CostDashboard";
+import Settings from "./components/Settings";
 import LanguageSwitcher from "./components/LanguageSwitcher";
 
 function NavLink({ to, children }: { to: string; children: React.ReactNode }) {
@@ -37,6 +38,7 @@ function App() {
               <nav className="flex gap-2">
                 <NavLink to="/">{t("nav.dashboard")}</NavLink>
                 <NavLink to="/costs">{t("nav.costs")}</NavLink>
+                <NavLink to="/settings">{t("nav.settings")}</NavLink>
               </nav>
               <LanguageSwitcher />
             </div>
@@ -47,6 +49,7 @@ function App() {
             <Route path="/" element={<Dashboard />} />
             <Route path="/episodes/:id" element={<EpisodeDetail />} />
             <Route path="/costs" element={<CostDashboard />} />
+            <Route path="/settings" element={<Settings />} />
           </Routes>
         </main>
       </div>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -6,6 +6,8 @@ import type {
   PipelineStep,
   CostStatsResponse,
   EpisodeCostResponse,
+  ArticleInput,
+  ModelPricing,
 } from "../types";
 
 const client = axios.create({
@@ -17,19 +19,34 @@ export const api = {
   getEpisode: (id: number) => client.get<Episode>(`/episodes/${id}`),
   createEpisode: (title: string) =>
     client.post<Episode>("/episodes", { title }),
+  createEpisodeFromArticles: (title: string, articles: ArticleInput[]) =>
+    client.post<Episode>("/episodes/from-articles", { title, articles }),
   getSteps: (episodeId: number) =>
     client.get<PipelineStep[]>(`/episodes/${episodeId}/steps`),
   getNewsItems: (episodeId: number) =>
     client.get<NewsItem[]>(`/episodes/${episodeId}/news-items`),
-  runStep: (episodeId: number, stepName: string) =>
-    client.post<PipelineStep>(`/episodes/${episodeId}/steps/${stepName}/run`),
+  runStep: (episodeId: number, stepName: string, body?: { queries?: string[] }) =>
+    client.post<PipelineStep>(`/episodes/${episodeId}/steps/${stepName}/run`, body),
   approveStep: (stepId: number) =>
     client.post<PipelineStep>(`/steps/${stepId}/approve`),
   rejectStep: (stepId: number, reason: string) =>
     client.post<PipelineStep>(`/steps/${stepId}/reject`, { reason }),
-  getCostStats: () => client.get<CostStatsResponse>("/stats/costs"),
+  getCostStats: (from?: string, to?: string) => {
+    const params = new URLSearchParams();
+    if (from) params.set("from", from);
+    if (to) params.set("to", to);
+    const qs = params.toString();
+    return client.get<CostStatsResponse>(`/stats/costs${qs ? `?${qs}` : ""}`);
+  },
   getEpisodeCosts: (id: number) =>
     client.get<EpisodeCostResponse>(`/stats/costs/episodes/${id}`),
+  // Pricing CRUD
+  getPricing: () => client.get<ModelPricing[]>("/pricing"),
+  createPricing: (data: { model_prefix: string; provider: string; input_price_per_1m: number; output_price_per_1m: number }) =>
+    client.post<ModelPricing>("/pricing", data),
+  updatePricing: (id: number, data: { model_prefix: string; provider: string; input_price_per_1m: number; output_price_per_1m: number }) =>
+    client.put<ModelPricing>(`/pricing/${id}`, data),
+  deletePricing: (id: number) => client.delete(`/pricing/${id}`),
 };
 
 export default client;

--- a/frontend/src/components/CostDashboard.tsx
+++ b/frontend/src/components/CostDashboard.tsx
@@ -3,113 +3,157 @@ import { useTranslation } from "react-i18next";
 import { api } from "../api/client";
 import type { CostStatsResponse } from "../types";
 
+type DatePreset = "today" | "7d" | "30d" | "all";
+
+function getDateRange(preset: DatePreset): { from?: string; to?: string } {
+  if (preset === "all") return {};
+  const to = new Date().toISOString().split("T")[0];
+  const from = new Date();
+  if (preset === "today") {
+    // same day
+  } else if (preset === "7d") {
+    from.setDate(from.getDate() - 7);
+  } else if (preset === "30d") {
+    from.setDate(from.getDate() - 30);
+  }
+  return { from: from.toISOString().split("T")[0], to };
+}
+
 export default function CostDashboard() {
   const { t } = useTranslation();
   const [stats, setStats] = useState<CostStatsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [preset, setPreset] = useState<DatePreset>("all");
 
-  const fetch = useCallback(async () => {
+  const fetchData = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
-      const res = await api.getCostStats();
+      const { from, to } = getDateRange(preset);
+      const res = await api.getCostStats(from, to);
       setStats(res.data);
     } catch (e) {
       setError(e instanceof Error ? e.message : t("costs.fetchFailed"));
     } finally {
       setLoading(false);
     }
-  }, [t]);
+  }, [t, preset]);
 
   useEffect(() => {
-    fetch();
-  }, [fetch]);
-
-  if (loading) return <p className="text-gray-500">{t("costs.loading")}</p>;
-  if (error) return <p className="text-red-600">{error}</p>;
-  if (!stats) return null;
+    fetchData();
+  }, [fetchData]);
 
   const formatCost = (usd: number) => `$${usd.toFixed(4)}`;
   const formatTokens = (n: number) => n.toLocaleString();
+
+  const presets: { key: DatePreset; label: string }[] = [
+    { key: "today", label: t("costs.presetToday") },
+    { key: "7d", label: t("costs.preset7d") },
+    { key: "30d", label: t("costs.preset30d") },
+    { key: "all", label: t("costs.presetAll") },
+  ];
 
   return (
     <div>
       <h2 className="text-xl font-semibold text-gray-800 mb-6">{t("costs.title")}</h2>
 
-      <div className="grid grid-cols-2 gap-4 mb-6">
-        <div className="bg-white rounded-lg shadow p-4">
-          <p className="text-sm text-gray-500">{t("costs.totalCost")}</p>
-          <p className="text-2xl font-bold text-gray-900">{formatCost(stats.total_cost_usd)}</p>
-        </div>
-        <div className="bg-white rounded-lg shadow p-4">
-          <p className="text-sm text-gray-500">{t("costs.totalRequests")}</p>
-          <p className="text-2xl font-bold text-gray-900">{stats.total_requests.toLocaleString()}</p>
-        </div>
+      {/* Date filter */}
+      <div className="flex gap-2 mb-6">
+        {presets.map((p) => (
+          <button
+            key={p.key}
+            onClick={() => setPreset(p.key)}
+            className={`px-3 py-1.5 text-sm rounded-md font-medium cursor-pointer ${
+              preset === p.key
+                ? "bg-blue-600 text-white"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+            }`}
+          >
+            {p.label}
+          </button>
+        ))}
       </div>
 
-      {stats.by_provider.length > 0 && (
-        <div className="mb-6">
-          <h3 className="text-base font-semibold text-gray-700 mb-3">{t("costs.byProvider")}</h3>
-          <div className="bg-white rounded-lg shadow overflow-hidden">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-50 border-b border-gray-200">
-                <tr>
-                  <th className="text-left px-4 py-3 font-medium text-gray-600">{t("costs.provider")}</th>
-                  <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.inputTokens")}</th>
-                  <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.outputTokens")}</th>
-                  <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.cost")}</th>
-                  <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.requests")}</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {stats.by_provider.map((row) => (
-                  <tr key={row.provider}>
-                    <td className="px-4 py-3 font-medium text-gray-900">{row.provider}</td>
-                    <td className="px-4 py-3 text-right text-gray-600">{formatTokens(row.total_input_tokens)}</td>
-                    <td className="px-4 py-3 text-right text-gray-600">{formatTokens(row.total_output_tokens)}</td>
-                    <td className="px-4 py-3 text-right text-gray-900 font-medium">{formatCost(row.total_cost_usd)}</td>
-                    <td className="px-4 py-3 text-right text-gray-600">{row.request_count}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+      {loading && <p className="text-gray-500">{t("costs.loading")}</p>}
+      {error && <p className="text-red-600">{error}</p>}
+      {!loading && !error && stats && (
+        <>
+          <div className="grid grid-cols-2 gap-4 mb-6">
+            <div className="bg-white rounded-lg shadow p-4">
+              <p className="text-sm text-gray-500">{t("costs.totalCost")}</p>
+              <p className="text-2xl font-bold text-gray-900">{formatCost(stats.total_cost_usd)}</p>
+            </div>
+            <div className="bg-white rounded-lg shadow p-4">
+              <p className="text-sm text-gray-500">{t("costs.totalRequests")}</p>
+              <p className="text-2xl font-bold text-gray-900">{stats.total_requests.toLocaleString()}</p>
+            </div>
           </div>
-        </div>
-      )}
 
-      {stats.by_step.length > 0 && (
-        <div>
-          <h3 className="text-base font-semibold text-gray-700 mb-3">{t("costs.byStep")}</h3>
-          <div className="bg-white rounded-lg shadow overflow-hidden">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-50 border-b border-gray-200">
-                <tr>
-                  <th className="text-left px-4 py-3 font-medium text-gray-600">{t("costs.step")}</th>
-                  <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.inputTokens")}</th>
-                  <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.outputTokens")}</th>
-                  <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.cost")}</th>
-                  <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.requests")}</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {stats.by_step.map((row) => (
-                  <tr key={row.step_name}>
-                    <td className="px-4 py-3 font-medium text-gray-900">{t(`steps.${row.step_name}`)}</td>
-                    <td className="px-4 py-3 text-right text-gray-600">{formatTokens(row.total_input_tokens)}</td>
-                    <td className="px-4 py-3 text-right text-gray-600">{formatTokens(row.total_output_tokens)}</td>
-                    <td className="px-4 py-3 text-right text-gray-900 font-medium">{formatCost(row.total_cost_usd)}</td>
-                    <td className="px-4 py-3 text-right text-gray-600">{row.request_count}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      )}
+          {stats.by_provider.length > 0 && (
+            <div className="mb-6">
+              <h3 className="text-base font-semibold text-gray-700 mb-3">{t("costs.byProvider")}</h3>
+              <div className="bg-white rounded-lg shadow overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead className="bg-gray-50 border-b border-gray-200">
+                    <tr>
+                      <th className="text-left px-4 py-3 font-medium text-gray-600">{t("costs.provider")}</th>
+                      <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.inputTokens")}</th>
+                      <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.outputTokens")}</th>
+                      <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.cost")}</th>
+                      <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.requests")}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {stats.by_provider.map((row) => (
+                      <tr key={row.provider}>
+                        <td className="px-4 py-3 font-medium text-gray-900">{row.provider}</td>
+                        <td className="px-4 py-3 text-right text-gray-600">{formatTokens(row.total_input_tokens)}</td>
+                        <td className="px-4 py-3 text-right text-gray-600">{formatTokens(row.total_output_tokens)}</td>
+                        <td className="px-4 py-3 text-right text-gray-900 font-medium">{formatCost(row.total_cost_usd)}</td>
+                        <td className="px-4 py-3 text-right text-gray-600">{row.request_count}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
 
-      {stats.by_provider.length === 0 && stats.by_step.length === 0 && (
-        <p className="text-gray-500">{t("costs.noData")}</p>
+          {stats.by_step.length > 0 && (
+            <div>
+              <h3 className="text-base font-semibold text-gray-700 mb-3">{t("costs.byStep")}</h3>
+              <div className="bg-white rounded-lg shadow overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead className="bg-gray-50 border-b border-gray-200">
+                    <tr>
+                      <th className="text-left px-4 py-3 font-medium text-gray-600">{t("costs.step")}</th>
+                      <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.inputTokens")}</th>
+                      <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.outputTokens")}</th>
+                      <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.cost")}</th>
+                      <th className="text-right px-4 py-3 font-medium text-gray-600">{t("costs.requests")}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {stats.by_step.map((row) => (
+                      <tr key={row.step_name}>
+                        <td className="px-4 py-3 font-medium text-gray-900">{t(`steps.${row.step_name}`)}</td>
+                        <td className="px-4 py-3 text-right text-gray-600">{formatTokens(row.total_input_tokens)}</td>
+                        <td className="px-4 py-3 text-right text-gray-600">{formatTokens(row.total_output_tokens)}</td>
+                        <td className="px-4 py-3 text-right text-gray-900 font-medium">{formatCost(row.total_cost_usd)}</td>
+                        <td className="px-4 py-3 text-right text-gray-600">{row.request_count}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {stats.by_provider.length === 0 && stats.by_step.length === 0 && (
+            <p className="text-gray-500">{t("costs.noData")}</p>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { api } from "../api/client";
 import { useEpisodes } from "../hooks/useEpisodes";
-import type { EpisodeStatus } from "../types";
+import type { ArticleInput, EpisodeStatus } from "../types";
 
 const STATUS_STYLES: Record<EpisodeStatus, { bg: string; text: string }> = {
   draft: { bg: "bg-gray-100", text: "text-gray-700" },
@@ -12,6 +12,8 @@ const STATUS_STYLES: Record<EpisodeStatus, { bg: string; text: string }> = {
   published: { bg: "bg-purple-100", text: "text-purple-700" },
 };
 
+type CreateMode = "search" | "articles";
+
 export default function Dashboard() {
   const { t } = useTranslation();
   const { episodes, loading, error, refetch } = useEpisodes();
@@ -19,13 +21,41 @@ export default function Dashboard() {
   const [newTitle, setNewTitle] = useState("");
   const [creating, setCreating] = useState(false);
   const [showForm, setShowForm] = useState(false);
+  const [createMode, setCreateMode] = useState<CreateMode>("search");
+  const [queries, setQueries] = useState("");
+  const [articlesText, setArticlesText] = useState("");
 
-  const handleCreate = async () => {
+  const handleCreateSearch = async () => {
     if (!newTitle.trim()) return;
     try {
       setCreating(true);
       const res = await api.createEpisode(newTitle.trim());
+      const episodeId = res.data.id;
+      // Run collection step with custom queries if provided
+      if (queries.trim()) {
+        const queryList = queries.split(",").map((q) => q.trim()).filter(Boolean);
+        await api.runStep(episodeId, "collection", { queries: queryList });
+      }
       setNewTitle("");
+      setQueries("");
+      setShowForm(false);
+      navigate(`/episodes/${episodeId}`);
+    } catch {
+      refetch();
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleCreateArticles = async () => {
+    if (!newTitle.trim() || !articlesText.trim()) return;
+    try {
+      setCreating(true);
+      const articles = parseArticles(articlesText);
+      if (articles.length === 0) return;
+      const res = await api.createEpisodeFromArticles(newTitle.trim(), articles);
+      setNewTitle("");
+      setArticlesText("");
       setShowForm(false);
       navigate(`/episodes/${res.data.id}`);
     } catch {
@@ -54,32 +84,84 @@ export default function Dashboard() {
       </div>
 
       {showForm && (
-        <div className="mb-6 flex gap-2">
+        <div className="mb-6 bg-white rounded-lg shadow p-4">
+          {/* Mode selector */}
+          <div className="flex gap-2 mb-4">
+            <button
+              onClick={() => setCreateMode("search")}
+              className={`px-3 py-1.5 text-sm rounded-md font-medium ${
+                createMode === "search"
+                  ? "bg-blue-600 text-white"
+                  : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              } cursor-pointer`}
+            >
+              {t("dashboard.modeSearch")}
+            </button>
+            <button
+              onClick={() => setCreateMode("articles")}
+              className={`px-3 py-1.5 text-sm rounded-md font-medium ${
+                createMode === "articles"
+                  ? "bg-blue-600 text-white"
+                  : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              } cursor-pointer`}
+            >
+              {t("dashboard.modeArticles")}
+            </button>
+          </div>
+
+          {/* Title input */}
           <input
             type="text"
             value={newTitle}
             onChange={(e) => setNewTitle(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && handleCreate()}
             placeholder={t("dashboard.titlePlaceholder")}
-            className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm mb-3"
             autoFocus
           />
-          <button
-            onClick={handleCreate}
-            disabled={creating || !newTitle.trim()}
-            className="px-4 py-2 bg-green-600 text-white rounded-md text-sm font-medium hover:bg-green-700 disabled:opacity-50 cursor-pointer"
-          >
-            {creating ? t("dashboard.creating") : t("dashboard.create")}
-          </button>
-          <button
-            onClick={() => {
-              setShowForm(false);
-              setNewTitle("");
-            }}
-            className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-300 cursor-pointer"
-          >
-            {t("dashboard.cancel")}
-          </button>
+
+          {/* Search mode */}
+          {createMode === "search" && (
+            <div className="mb-3">
+              <input
+                type="text"
+                value={queries}
+                onChange={(e) => setQueries(e.target.value)}
+                placeholder={t("dashboard.queriesPlaceholder")}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              />
+              <p className="text-xs text-gray-400 mt-1">{t("dashboard.queriesHint")}</p>
+            </div>
+          )}
+
+          {/* Articles mode */}
+          {createMode === "articles" && (
+            <div className="mb-3">
+              <textarea
+                value={articlesText}
+                onChange={(e) => setArticlesText(e.target.value)}
+                placeholder={t("dashboard.articlesPlaceholder")}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm h-40 font-mono"
+              />
+              <p className="text-xs text-gray-400 mt-1">{t("dashboard.articlesHint")}</p>
+            </div>
+          )}
+
+          {/* Action buttons */}
+          <div className="flex gap-2">
+            <button
+              onClick={createMode === "search" ? handleCreateSearch : handleCreateArticles}
+              disabled={creating || !newTitle.trim() || (createMode === "articles" && !articlesText.trim())}
+              className="px-4 py-2 bg-green-600 text-white rounded-md text-sm font-medium hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+            >
+              {creating ? t("dashboard.creating") : t("dashboard.create")}
+            </button>
+            <button
+              onClick={() => { setShowForm(false); setNewTitle(""); setQueries(""); setArticlesText(""); }}
+              className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-300 cursor-pointer"
+            >
+              {t("dashboard.cancel")}
+            </button>
+          </div>
         </div>
       )}
 
@@ -131,4 +213,32 @@ export default function Dashboard() {
       )}
     </div>
   );
+}
+
+function parseArticles(text: string): ArticleInput[] {
+  // Try JSON first
+  try {
+    const parsed = JSON.parse(text);
+    if (Array.isArray(parsed)) return parsed;
+    return [parsed];
+  } catch {
+    // Fall through to line-based parsing
+  }
+
+  // Line-based: "title | url | source_name" per line
+  const articles: ArticleInput[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parts = trimmed.split("|").map((p) => p.trim());
+    if (parts.length >= 3) {
+      articles.push({
+        title: parts[0],
+        source_url: parts[1],
+        source_name: parts[2],
+        summary: parts[3] || undefined,
+      });
+    }
+  }
+  return articles;
 }

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1,0 +1,215 @@
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { api } from "../api/client";
+import type { ModelPricing } from "../types";
+
+export default function Settings() {
+  const { t } = useTranslation();
+  const [pricing, setPricing] = useState<ModelPricing[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [showAdd, setShowAdd] = useState(false);
+  const [form, setForm] = useState({ model_prefix: "", provider: "", input_price_per_1m: 0, output_price_per_1m: 0 });
+
+  const fetchPricing = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await api.getPricing();
+      setPricing(res.data);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPricing();
+  }, [fetchPricing]);
+
+  const handleAdd = async () => {
+    if (!form.model_prefix || !form.provider) return;
+    await api.createPricing(form);
+    setForm({ model_prefix: "", provider: "", input_price_per_1m: 0, output_price_per_1m: 0 });
+    setShowAdd(false);
+    fetchPricing();
+  };
+
+  const handleUpdate = async (id: number) => {
+    const item = pricing.find((p) => p.id === id);
+    if (!item) return;
+    await api.updatePricing(id, {
+      model_prefix: item.model_prefix,
+      provider: item.provider,
+      input_price_per_1m: item.input_price_per_1m,
+      output_price_per_1m: item.output_price_per_1m,
+    });
+    setEditingId(null);
+    fetchPricing();
+  };
+
+  const handleDelete = async (id: number) => {
+    await api.deletePricing(id);
+    fetchPricing();
+  };
+
+  const updateRow = (id: number, field: string, value: string | number) => {
+    setPricing((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, [field]: value } : p))
+    );
+  };
+
+  // Group by provider
+  const providers = [...new Set(pricing.map((p) => p.provider))].sort();
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold text-gray-800 mb-6">{t("settings.title")}</h2>
+
+      {/* Model Pricing Table */}
+      <div className="mb-8">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-base font-semibold text-gray-700">{t("settings.pricing.title")}</h3>
+          <button
+            onClick={() => setShowAdd(!showAdd)}
+            className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md font-medium hover:bg-blue-700 cursor-pointer"
+          >
+            {t("settings.pricing.add")}
+          </button>
+        </div>
+
+        {showAdd && (
+          <div className="bg-gray-50 rounded-lg p-4 mb-4 flex gap-2 items-end flex-wrap">
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">{t("settings.pricing.modelPrefix")}</label>
+              <input
+                type="text"
+                value={form.model_prefix}
+                onChange={(e) => setForm({ ...form, model_prefix: e.target.value })}
+                className="px-2 py-1.5 border border-gray-300 rounded text-sm w-40"
+                placeholder="gpt-5"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">{t("settings.pricing.provider")}</label>
+              <input
+                type="text"
+                value={form.provider}
+                onChange={(e) => setForm({ ...form, provider: e.target.value })}
+                className="px-2 py-1.5 border border-gray-300 rounded text-sm w-28"
+                placeholder="openai"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">{t("settings.pricing.inputPrice")}</label>
+              <input
+                type="number"
+                step="0.01"
+                value={form.input_price_per_1m}
+                onChange={(e) => setForm({ ...form, input_price_per_1m: parseFloat(e.target.value) || 0 })}
+                className="px-2 py-1.5 border border-gray-300 rounded text-sm w-24"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">{t("settings.pricing.outputPrice")}</label>
+              <input
+                type="number"
+                step="0.01"
+                value={form.output_price_per_1m}
+                onChange={(e) => setForm({ ...form, output_price_per_1m: parseFloat(e.target.value) || 0 })}
+                className="px-2 py-1.5 border border-gray-300 rounded text-sm w-24"
+              />
+            </div>
+            <button
+              onClick={handleAdd}
+              disabled={!form.model_prefix || !form.provider}
+              className="px-3 py-1.5 bg-green-600 text-white rounded text-sm font-medium hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+            >
+              {t("settings.pricing.save")}
+            </button>
+          </div>
+        )}
+
+        {loading ? (
+          <p className="text-gray-500 text-sm">{t("settings.loading")}</p>
+        ) : (
+          providers.map((provider) => (
+            <div key={provider} className="mb-4">
+              <h4 className="text-sm font-medium text-gray-500 mb-2 uppercase">{provider}</h4>
+              <div className="bg-white rounded-lg shadow overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead className="bg-gray-50 border-b border-gray-200">
+                    <tr>
+                      <th className="text-left px-4 py-2 font-medium text-gray-600">{t("settings.pricing.modelPrefix")}</th>
+                      <th className="text-right px-4 py-2 font-medium text-gray-600">{t("settings.pricing.inputPrice")}</th>
+                      <th className="text-right px-4 py-2 font-medium text-gray-600">{t("settings.pricing.outputPrice")}</th>
+                      <th className="text-right px-4 py-2 font-medium text-gray-600 w-28"></th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {pricing
+                      .filter((p) => p.provider === provider)
+                      .map((p) => (
+                        <tr key={p.id}>
+                          <td className="px-4 py-2 font-mono text-gray-900">{p.model_prefix}</td>
+                          <td className="px-4 py-2 text-right">
+                            {editingId === p.id ? (
+                              <input
+                                type="number"
+                                step="0.01"
+                                value={p.input_price_per_1m}
+                                onChange={(e) => updateRow(p.id, "input_price_per_1m", parseFloat(e.target.value) || 0)}
+                                className="w-24 px-1 py-0.5 border rounded text-right text-sm"
+                              />
+                            ) : (
+                              <span className="text-gray-600">${p.input_price_per_1m}</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-2 text-right">
+                            {editingId === p.id ? (
+                              <input
+                                type="number"
+                                step="0.01"
+                                value={p.output_price_per_1m}
+                                onChange={(e) => updateRow(p.id, "output_price_per_1m", parseFloat(e.target.value) || 0)}
+                                className="w-24 px-1 py-0.5 border rounded text-right text-sm"
+                              />
+                            ) : (
+                              <span className="text-gray-600">${p.output_price_per_1m}</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-2 text-right">
+                            {editingId === p.id ? (
+                              <button
+                                onClick={() => handleUpdate(p.id)}
+                                className="text-green-600 hover:text-green-800 text-xs font-medium cursor-pointer"
+                              >
+                                {t("settings.pricing.save")}
+                              </button>
+                            ) : (
+                              <span className="flex gap-2 justify-end">
+                                <button
+                                  onClick={() => setEditingId(p.id)}
+                                  className="text-blue-600 hover:text-blue-800 text-xs font-medium cursor-pointer"
+                                >
+                                  {t("settings.pricing.edit")}
+                                </button>
+                                <button
+                                  onClick={() => handleDelete(p.id)}
+                                  className="text-red-500 hover:text-red-700 text-xs font-medium cursor-pointer"
+                                >
+                                  {t("settings.pricing.delete")}
+                                </button>
+                              </span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -4,7 +4,8 @@
   },
   "nav": {
     "dashboard": "Dashboard",
-    "costs": "Cost Stats"
+    "costs": "Cost Stats",
+    "settings": "Settings"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -13,6 +14,12 @@
     "create": "Create",
     "creating": "Creating...",
     "cancel": "Cancel",
+    "modeSearch": "Search & Collect",
+    "modeArticles": "Direct Input",
+    "queriesPlaceholder": "Search queries (comma-separated)",
+    "queriesHint": "e.g.: Kumamoto news, Kumamoto politics (blank for defaults)",
+    "articlesPlaceholder": "JSON format:\n[\n  {\"title\": \"Article title\", \"source_url\": \"https://...\", \"source_name\": \"Source\", \"summary\": \"Summary\"}\n]\n\nOr one article per line:\nTitle | URL | Source | Summary",
+    "articlesHint": "JSON array or \"Title | URL | Source | Summary\" format (one per line)",
     "loading": "Loading...",
     "noEpisodes": "No episodes yet. Click \"New Episode\" to create one.",
     "table": {
@@ -90,7 +97,11 @@
     "requests": "Requests",
     "noData": "No API usage records yet.",
     "loading": "Loading...",
-    "fetchFailed": "Failed to fetch cost stats"
+    "fetchFailed": "Failed to fetch cost stats",
+    "presetToday": "Today",
+    "preset7d": "Last 7 days",
+    "preset30d": "Last 30 days",
+    "presetAll": "All time"
   },
   "stepData": {
     "collection": {
@@ -122,6 +133,21 @@
     "script": {
       "fullScript": "Full Episode Script",
       "perArticle": "Per-Article Scripts"
+    }
+  },
+  "settings": {
+    "title": "Settings",
+    "loading": "Loading...",
+    "pricing": {
+      "title": "Model Pricing (per 1M tokens/chars)",
+      "modelPrefix": "Model",
+      "provider": "Provider",
+      "inputPrice": "Input Price",
+      "outputPrice": "Output Price",
+      "add": "Add",
+      "edit": "Edit",
+      "save": "Save",
+      "delete": "Delete"
     }
   },
   "errors": {

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -4,7 +4,8 @@
   },
   "nav": {
     "dashboard": "ダッシュボード",
-    "costs": "コスト統計"
+    "costs": "コスト統計",
+    "settings": "設定"
   },
   "dashboard": {
     "title": "ダッシュボード",
@@ -13,6 +14,12 @@
     "create": "作成",
     "creating": "作成中...",
     "cancel": "キャンセル",
+    "modeSearch": "検索で収集",
+    "modeArticles": "記事を直接入力",
+    "queriesPlaceholder": "検索クエリ（カンマ区切り）",
+    "queriesHint": "例: 熊本 ニュース, 熊本県 政治（空欄でデフォルトクエリを使用）",
+    "articlesPlaceholder": "JSON形式:\n[\n  {\"title\": \"記事タイトル\", \"source_url\": \"https://...\", \"source_name\": \"ソース名\", \"summary\": \"要約\"}\n]\n\nまたは1行1記事:\nタイトル | URL | ソース名 | 要約",
+    "articlesHint": "JSON配列または「タイトル | URL | ソース名 | 要約」形式（1行1記事）",
     "loading": "読み込み中...",
     "noEpisodes": "エピソードがありません。「新規エピソード」で作成してください。",
     "table": {
@@ -90,7 +97,11 @@
     "requests": "リクエスト数",
     "noData": "まだAPIの使用記録がありません。",
     "loading": "読み込み中...",
-    "fetchFailed": "コスト統計の取得に失敗しました"
+    "fetchFailed": "コスト統計の取得に失敗しました",
+    "presetToday": "今日",
+    "preset7d": "過去7日",
+    "preset30d": "過去30日",
+    "presetAll": "全期間"
   },
   "stepData": {
     "collection": {
@@ -122,6 +133,21 @@
     "script": {
       "fullScript": "エピソード全体台本",
       "perArticle": "記事別台本"
+    }
+  },
+  "settings": {
+    "title": "設定",
+    "loading": "読み込み中...",
+    "pricing": {
+      "title": "モデル料金テーブル（per 1M tokens/chars）",
+      "modelPrefix": "モデル",
+      "provider": "プロバイダー",
+      "inputPrice": "入力料金",
+      "outputPrice": "出力料金",
+      "add": "追加",
+      "edit": "編集",
+      "save": "保存",
+      "delete": "削除"
     }
   },
   "errors": {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -92,3 +92,20 @@ export interface EpisodeCostResponse {
   total_cost_usd: number;
   total_requests: number;
 }
+
+export interface ArticleInput {
+  title: string;
+  summary?: string;
+  source_url: string;
+  source_name: string;
+}
+
+export interface ModelPricing {
+  id: number;
+  model_prefix: string;
+  provider: string;
+  input_price_per_1m: number;
+  output_price_per_1m: number;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary

3つのイシューをまとめて実装:

### #28 ダッシュボードUI拡張
- 2モード選択: 「検索で収集」（クエリ指定可）/ 「記事を直接入力」（JSON or パイプ区切り）
- from-articles API連携

### #29 + #25 設定画面
- `/settings` ページ新設
- モデル料金テーブルのCRUD管理（プロバイダー別グループ表示）

### #33 コスト期間フィルタ
- プリセット: 今日 / 過去7日 / 過去30日 / 全期間
- バックエンド: `GET /api/stats/costs?from=2026-03-01&to=2026-03-31`

Closes #28, Closes #29, Closes #25, Closes #33

## Test plan
- [x] TypeScript型チェック通過
- [x] バックエンド全APIテスト通過（20件）
- [ ] ブラウザでダッシュボード2モード確認
- [ ] 設定画面で料金CRUD操作確認
- [ ] コスト画面で期間フィルタ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)