### PR TITLE
feat: MCP サーバー対応 (#21)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,16 @@ cython_debug/
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 
+# MCP config (contains local paths and auth tokens)
+.mcp.json
+
+# Media files (generated audio/video)
+backend/media/
+
+# Frontend build cache
+frontend/.vite/
+frontend/tsconfig.tsbuildinfo
+
 # Ruff stuff:
 .ruff_cache/
 

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "ai-news-radio": {
+      "type": "stdio",
+      "command": "python",
+      "args": ["-m", "mcp_server"],
+      "cwd": "/path/to/ai-news-radio/backend",
+      "env": {
+        "AINEWSRADIO_BACKEND_URL": "http://localhost:8000",
+        "PYTHONPATH": "/path/to/ai-news-radio/backend"
+      }
+    }
+  }
+}

--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -1,0 +1,45 @@
+"""News search API endpoint using Brave Search."""
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from app.services.brave_search import BraveSearchService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/search", tags=["search"])
+
+
+class SearchResultResponse(BaseModel):
+    """A single search result."""
+
+    title: str
+    url: str
+    description: str
+    age: str | None = None
+
+
+@router.get("/news", response_model=list[SearchResultResponse])
+async def search_news(
+    q: str = Query(..., description="Search query"),
+    count: int = Query(10, ge=1, le=20, description="Number of results"),
+    freshness: str | None = Query(None, pattern="^(pd|pw|pm)$", description="Time filter: pd/pw/pm"),
+) -> list[SearchResultResponse]:
+    """Search for news articles using Brave Search."""
+    try:
+        service = BraveSearchService()
+    except ValueError as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+    results = await service.web_search(query=q, count=count, freshness=freshness)
+    return [
+        SearchResultResponse(
+            title=r.title,
+            url=r.url,
+            description=r.description,
+            age=r.age,
+        )
+        for r in results
+    ]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.api.episodes import router as episodes_router
 from app.api.health import router as health_router
 from app.api.pipeline import router as pipeline_router
 from app.api.pricing import router as pricing_router
+from app.api.search import router as search_router
 from app.api.stats import router as stats_router
 from app.config import settings
 
@@ -33,3 +34,4 @@ app.include_router(episodes_router, prefix="/api")
 app.include_router(pipeline_router, prefix="/api")
 app.include_router(stats_router, prefix="/api")
 app.include_router(pricing_router, prefix="/api")
+app.include_router(search_router, prefix="/api")

--- a/backend/mcp_server/__init__.py
+++ b/backend/mcp_server/__init__.py
@@ -1,0 +1,1 @@
+"""AI News Radio MCP Server - Claude Code integration via stdio transport."""

--- a/backend/mcp_server/__main__.py
+++ b/backend/mcp_server/__main__.py
@@ -1,0 +1,20 @@
+"""Entry point: python -m mcp_server"""
+
+import asyncio
+import logging
+
+from mcp.server.stdio import stdio_server
+
+from mcp_server.server import server
+
+logging.basicConfig(level=logging.INFO)
+
+
+async def main() -> None:
+    """Run the MCP server over stdio."""
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/mcp_server/client.py
+++ b/backend/mcp_server/client.py
@@ -1,0 +1,128 @@
+"""HTTP client for AI News Radio FastAPI backend."""
+
+from typing import Any
+
+import httpx
+
+from mcp_server.config import BACKEND_URL, REQUEST_TIMEOUT
+
+
+class APIError(Exception):
+    """API call failed with a meaningful message."""
+
+    def __init__(self, status_code: int, detail: str) -> None:
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"HTTP {status_code}: {detail}")
+
+
+class AINewsRadioClient:
+    """Async HTTP client wrapping the FastAPI backend API."""
+
+    def __init__(self, base_url: str = BACKEND_URL, timeout: float = REQUEST_TIMEOUT) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+    def _client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(base_url=self._base_url, timeout=self._timeout)
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> Any:
+        """Make an HTTP request and return parsed JSON."""
+        async with self._client() as client:
+            response = await client.request(method, path, **kwargs)
+        if response.status_code >= 400:
+            try:
+                detail = response.json().get("detail", response.text)
+            except Exception:
+                detail = response.text
+            raise APIError(response.status_code, detail)
+        if response.status_code == 204:
+            return None
+        return response.json()
+
+    # ---- Health ----
+
+    async def health(self) -> dict:
+        """GET /api/health"""
+        return await self._request("GET", "/api/health")
+
+    # ---- Episodes ----
+
+    async def create_episode(self, title: str) -> dict:
+        """POST /api/episodes"""
+        return await self._request("POST", "/api/episodes", json={"title": title})
+
+    async def create_episode_from_articles(self, title: str, articles: list[dict]) -> dict:
+        """POST /api/episodes/from-articles"""
+        return await self._request("POST", "/api/episodes/from-articles", json={"title": title, "articles": articles})
+
+    async def list_episodes(self) -> dict:
+        """GET /api/episodes"""
+        return await self._request("GET", "/api/episodes")
+
+    async def get_episode(self, episode_id: int) -> dict:
+        """GET /api/episodes/{episode_id}"""
+        return await self._request("GET", f"/api/episodes/{episode_id}")
+
+    async def get_news_items(self, episode_id: int) -> list[dict]:
+        """GET /api/episodes/{episode_id}/news-items"""
+        return await self._request("GET", f"/api/episodes/{episode_id}/news-items")
+
+    # ---- Pipeline ----
+
+    async def get_steps(self, episode_id: int) -> list[dict]:
+        """GET /api/episodes/{episode_id}/steps"""
+        return await self._request("GET", f"/api/episodes/{episode_id}/steps")
+
+    async def run_step(self, episode_id: int, step_name: str, queries: list[str] | None = None) -> dict:
+        """POST /api/episodes/{episode_id}/steps/{step_name}/run"""
+        body = {}
+        if queries:
+            body["queries"] = queries
+        return await self._request("POST", f"/api/episodes/{episode_id}/steps/{step_name}/run", json=body)
+
+    async def approve_step(self, step_id: int) -> dict:
+        """POST /api/steps/{step_id}/approve"""
+        return await self._request("POST", f"/api/steps/{step_id}/approve")
+
+    async def reject_step(self, step_id: int, reason: str) -> dict:
+        """POST /api/steps/{step_id}/reject"""
+        return await self._request("POST", f"/api/steps/{step_id}/reject", json={"reason": reason})
+
+    # ---- Step ID resolution ----
+
+    async def resolve_step_id(self, episode_id: int, step_name: str) -> int:
+        """Find the step_id for a given episode_id + step_name."""
+        steps = await self.get_steps(episode_id)
+        for step in steps:
+            if step["step_name"] == step_name:
+                return step["id"]
+        raise APIError(404, f"Step '{step_name}' not found for episode {episode_id}")
+
+    # ---- Stats ----
+
+    async def get_cost_stats(
+        self,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> dict:
+        """GET /api/stats/costs"""
+        params: dict[str, str] = {}
+        if from_date:
+            params["from"] = from_date
+        if to_date:
+            params["to"] = to_date
+        return await self._request("GET", "/api/stats/costs", params=params)
+
+    async def get_episode_cost(self, episode_id: int) -> dict:
+        """GET /api/stats/costs/episodes/{episode_id}"""
+        return await self._request("GET", f"/api/stats/costs/episodes/{episode_id}")
+
+    # ---- Search ----
+
+    async def search_news(self, query: str, count: int = 10, freshness: str | None = None) -> list[dict]:
+        """GET /api/search/news"""
+        params: dict[str, Any] = {"q": query, "count": count}
+        if freshness:
+            params["freshness"] = freshness
+        return await self._request("GET", "/api/search/news", params=params)

--- a/backend/mcp_server/config.py
+++ b/backend/mcp_server/config.py
@@ -1,0 +1,6 @@
+"""MCP server configuration."""
+
+import os
+
+BACKEND_URL = os.environ.get("AINEWSRADIO_BACKEND_URL", "http://localhost:8000")
+REQUEST_TIMEOUT = float(os.environ.get("AINEWSRADIO_TIMEOUT", "120"))

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -1,0 +1,316 @@
+"""MCP server implementation for AI News Radio."""
+
+import json
+import logging
+
+from mcp.server import Server
+from mcp.types import TextContent, Tool
+
+from mcp_server.client import AINewsRadioClient, APIError
+from mcp_server.tools import STEP_NAMES, get_tool_definitions
+
+logger = logging.getLogger(__name__)
+
+server = Server("ai-news-radio")
+client = AINewsRadioClient()
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    """Return available tools."""
+    return get_tool_definitions()
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    """Dispatch tool calls to handlers."""
+    try:
+        result = await _dispatch(name, arguments or {})
+        return [TextContent(type="text", text=result)]
+    except APIError as e:
+        return [TextContent(type="text", text=f"Error: {e.detail}")]
+    except Exception as e:
+        logger.exception("Tool %s failed", name)
+        return [TextContent(type="text", text=f"Error: {e}")]
+
+
+async def _dispatch(name: str, args: dict) -> str:
+    """Route tool name to handler and return formatted text."""
+    match name:
+        case "health_check":
+            return await _health_check()
+        case "create_episode":
+            return await _create_episode(args)
+        case "create_episode_from_articles":
+            return await _create_episode_from_articles(args)
+        case "list_episodes":
+            return await _list_episodes()
+        case "get_episode_status":
+            return await _get_episode_status(args)
+        case "run_step":
+            return await _run_step(args)
+        case "approve_step":
+            return await _approve_step(args)
+        case "reject_step":
+            return await _reject_step(args)
+        case "get_step_detail":
+            return await _get_step_detail(args)
+        case "search_news":
+            return await _search_news(args)
+        case "get_cost_stats":
+            return await _get_cost_stats(args)
+        case _:
+            return f"Unknown tool: {name}"
+
+
+# ---- Handlers ----
+
+
+async def _health_check() -> str:
+    data = await client.health()
+    return f"Backend status: {data.get('status', 'unknown')}"
+
+
+async def _create_episode(args: dict) -> str:
+    ep = await client.create_episode(args["title"])
+    return _format_episode(ep)
+
+
+async def _create_episode_from_articles(args: dict) -> str:
+    ep = await client.create_episode_from_articles(args["title"], args["articles"])
+    return _format_episode(ep)
+
+
+async def _list_episodes() -> str:
+    data = await client.list_episodes()
+    episodes = data.get("episodes", [])
+    if not episodes:
+        return "No episodes found."
+
+    lines = [f"Episodes ({data.get('total', len(episodes))} total):", ""]
+    for ep in episodes:
+        steps = ep.get("pipeline_steps", [])
+        step_summary = _step_summary(steps)
+        lines.append(f"  #{ep['id']} [{ep['status']}] {ep['title']}")
+        lines.append(f"    Steps: {step_summary}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+async def _get_episode_status(args: dict) -> str:
+    episode_id = args["episode_id"]
+    ep = await client.get_episode(episode_id)
+    news_items = await client.get_news_items(episode_id)
+
+    lines = [
+        f"Episode #{ep['id']}: {ep['title']}",
+        f"Status: {ep['status']}",
+        f"Created: {ep.get('created_at', 'N/A')}",
+        "",
+        "Pipeline Steps:",
+    ]
+
+    for step in ep.get("pipeline_steps", []):
+        status = step["status"]
+        icon = _status_icon(status)
+        line = f"  {icon} {step['step_name']}: {status}"
+        if step.get("started_at") and not step.get("completed_at"):
+            line += " (running...)"
+        elif step.get("completed_at"):
+            line += f" (completed: {step['completed_at']})"
+        if step.get("rejection_reason"):
+            line += f" — reason: {step['rejection_reason']}"
+        lines.append(line)
+
+    if news_items:
+        lines.extend(["", f"News Items ({len(news_items)}):"])
+        for item in news_items:
+            fc = ""
+            if item.get("fact_check_score") is not None:
+                fc = f" [fact-check: {item['fact_check_score']}/5]"
+            script = " [script: ready]" if item.get("script_text") else ""
+            lines.append(f"  - {item['title']}{fc}{script}")
+            lines.append(f"    {item['source_name']}: {item['source_url']}")
+
+    return "\n".join(lines)
+
+
+async def _run_step(args: dict) -> str:
+    episode_id = args["episode_id"]
+    step_name = args["step_name"]
+    queries = args.get("queries")
+
+    step = await client.run_step(episode_id, step_name, queries)
+
+    lines = [
+        f"Step '{step_name}' started for episode #{episode_id}.",
+        f"Status: {step['status']}",
+        "",
+        "The step is running in the background.",
+        "Use get_episode_status to check for completion.",
+    ]
+    return "\n".join(lines)
+
+
+async def _approve_step(args: dict) -> str:
+    episode_id = args["episode_id"]
+    step_name = args["step_name"]
+
+    step_id = await client.resolve_step_id(episode_id, step_name)
+    step = await client.approve_step(step_id)
+
+    next_step = _next_step(step_name)
+    lines = [f"Step '{step_name}' approved for episode #{episode_id}."]
+    if next_step:
+        lines.append(f"Next step: run_step with step_name='{next_step}'")
+    else:
+        lines.append("This was the final step. Episode pipeline is complete.")
+    return "\n".join(lines)
+
+
+async def _reject_step(args: dict) -> str:
+    episode_id = args["episode_id"]
+    step_name = args["step_name"]
+    reason = args["reason"]
+
+    step_id = await client.resolve_step_id(episode_id, step_name)
+    await client.reject_step(step_id, reason)
+
+    return f"Step '{step_name}' rejected for episode #{episode_id}.\nReason: {reason}\nYou can re-run this step with run_step."
+
+
+async def _get_step_detail(args: dict) -> str:
+    episode_id = args["episode_id"]
+    step_name = args["step_name"]
+
+    steps = await client.get_steps(episode_id)
+    step = None
+    for s in steps:
+        if s["step_name"] == step_name:
+            step = s
+            break
+
+    if not step:
+        return f"Step '{step_name}' not found for episode #{episode_id}."
+
+    lines = [
+        f"Step: {step_name} (Episode #{episode_id})",
+        f"Status: {step['status']}",
+        f"Started: {step.get('started_at', 'N/A')}",
+        f"Completed: {step.get('completed_at', 'N/A')}",
+    ]
+
+    if step.get("input_data"):
+        lines.extend(["", "Input Data:", json.dumps(step["input_data"], ensure_ascii=False, indent=2)])
+
+    if step.get("output_data"):
+        lines.extend(["", "Output Data:", json.dumps(step["output_data"], ensure_ascii=False, indent=2)])
+
+    if step.get("rejection_reason"):
+        lines.extend(["", f"Rejection Reason: {step['rejection_reason']}"])
+
+    return "\n".join(lines)
+
+
+async def _search_news(args: dict) -> str:
+    query = args["query"]
+    count = args.get("count", 10)
+    freshness = args.get("freshness")
+
+    results = await client.search_news(query, count, freshness)
+
+    if not results:
+        return f"No results found for '{query}'."
+
+    lines = [f"Search results for '{query}' ({len(results)} results):", ""]
+    for i, r in enumerate(results, 1):
+        lines.append(f"{i}. {r['title']}")
+        lines.append(f"   URL: {r['url']}")
+        if r.get("description"):
+            lines.append(f"   {r['description']}")
+        if r.get("age"):
+            lines.append(f"   Age: {r['age']}")
+        lines.append("")
+
+    lines.append("Use create_episode_from_articles to create an episode with selected articles.")
+    return "\n".join(lines)
+
+
+async def _get_cost_stats(args: dict) -> str:
+    episode_id = args.get("episode_id")
+
+    if episode_id:
+        data = await client.get_episode_cost(episode_id)
+        lines = [
+            f"Cost Stats for Episode #{episode_id}:",
+            f"Total: ${data['total_cost_usd']:.4f} ({data['total_requests']} requests)",
+        ]
+    else:
+        data = await client.get_cost_stats(args.get("from_date"), args.get("to_date"))
+        lines = [
+            "Cost Stats:",
+            f"Total: ${data['total_cost_usd']:.4f} ({data['total_requests']} requests)",
+        ]
+
+    if data.get("by_provider"):
+        lines.extend(["", "By Provider:"])
+        for p in data["by_provider"]:
+            lines.append(f"  {p['provider']}: ${p['total_cost_usd']:.4f} ({p['request_count']} requests)")
+
+    if data.get("by_step"):
+        lines.extend(["", "By Step:"])
+        for s in data["by_step"]:
+            lines.append(f"  {s['step_name']}: ${s['total_cost_usd']:.4f} ({s['request_count']} requests)")
+
+    return "\n".join(lines)
+
+
+# ---- Formatting helpers ----
+
+
+def _format_episode(ep: dict) -> str:
+    """Format a single episode response."""
+    lines = [
+        f"Episode #{ep['id']} created.",
+        f"Title: {ep['title']}",
+        f"Status: {ep['status']}",
+        "",
+        "Pipeline Steps:",
+    ]
+    for step in ep.get("pipeline_steps", []):
+        icon = _status_icon(step["status"])
+        lines.append(f"  {icon} {step['step_name']}: {step['status']}")
+    return "\n".join(lines)
+
+
+def _status_icon(status: str) -> str:
+    """Return a text icon for step status."""
+    return {
+        "pending": "[ ]",
+        "running": "[~]",
+        "needs_approval": "[?]",
+        "approved": "[v]",
+        "rejected": "[x]",
+    }.get(status, "[-]")
+
+
+def _step_summary(steps: list[dict]) -> str:
+    """One-line summary of step statuses."""
+    if not steps:
+        return "no steps"
+    parts = []
+    for s in steps:
+        icon = _status_icon(s["status"])
+        parts.append(f"{icon}{s['step_name']}")
+    return " ".join(parts)
+
+
+def _next_step(step_name: str) -> str | None:
+    """Return the next step in the pipeline, or None if last."""
+    try:
+        idx = STEP_NAMES.index(step_name)
+        if idx + 1 < len(STEP_NAMES):
+            return STEP_NAMES[idx + 1]
+    except ValueError:
+        pass
+    return None

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -1,0 +1,202 @@
+"""MCP tool definitions for AI News Radio."""
+
+from mcp.types import Tool, ToolAnnotations
+
+STEP_NAMES = ["collection", "factcheck", "analysis", "script", "voice", "video", "publish"]
+
+
+def get_tool_definitions() -> list[Tool]:
+    """Return all MCP tool definitions."""
+    return [
+        # ---- Episode Lifecycle ----
+        Tool(
+            name="create_episode",
+            description="Create a new episode with 7 pipeline steps initialized (all pending). Returns the episode with its pipeline steps.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string", "description": "Episode title"},
+                },
+                "required": ["title"],
+            },
+            annotations=ToolAnnotations(destructiveHint=False, readOnlyHint=False),
+        ),
+        Tool(
+            name="create_episode_from_articles",
+            description=(
+                "Create an episode with pre-selected articles. "
+                "The collection step is auto-approved. Use after search_news to pass curated articles."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string", "description": "Episode title"},
+                    "articles": {
+                        "type": "array",
+                        "description": "List of news articles",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "title": {"type": "string", "description": "Article headline"},
+                                "summary": {"type": "string", "description": "Article summary (optional)"},
+                                "source_url": {"type": "string", "description": "Article URL"},
+                                "source_name": {"type": "string", "description": "Source name (e.g. NHK, 熊本日日新聞)"},
+                            },
+                            "required": ["title", "source_url", "source_name"],
+                        },
+                        "minItems": 1,
+                    },
+                },
+                "required": ["title", "articles"],
+            },
+            annotations=ToolAnnotations(destructiveHint=False, readOnlyHint=False),
+        ),
+        Tool(
+            name="list_episodes",
+            description="List all episodes with their current status and pipeline step summary.",
+            inputSchema={"type": "object", "properties": {}},
+            annotations=ToolAnnotations(readOnlyHint=True),
+        ),
+        # ---- Pipeline Operations ----
+        Tool(
+            name="get_episode_status",
+            description=(
+                "Get comprehensive episode status: pipeline steps with their statuses, "
+                "and news items with fact-check scores and script status."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "episode_id": {"type": "integer", "description": "Episode ID"},
+                },
+                "required": ["episode_id"],
+            },
+            annotations=ToolAnnotations(readOnlyHint=True),
+        ),
+        Tool(
+            name="run_step",
+            description=(
+                "Execute a pipeline step (runs in background). Returns immediately. "
+                "Use get_episode_status to poll for completion. "
+                "Steps must run in order: collection → factcheck → analysis → script → voice → video → publish. "
+                "Previous step must be approved before running the next."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "episode_id": {"type": "integer", "description": "Episode ID"},
+                    "step_name": {
+                        "type": "string",
+                        "enum": STEP_NAMES,
+                        "description": "Pipeline step to execute",
+                    },
+                    "queries": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Search queries for collection step (optional, uses default if omitted)",
+                    },
+                },
+                "required": ["episode_id", "step_name"],
+            },
+            annotations=ToolAnnotations(destructiveHint=False, readOnlyHint=False),
+        ),
+        Tool(
+            name="approve_step",
+            description="Approve a completed pipeline step (status must be needs_approval). Allows the next step to proceed.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "episode_id": {"type": "integer", "description": "Episode ID"},
+                    "step_name": {
+                        "type": "string",
+                        "enum": STEP_NAMES,
+                        "description": "Pipeline step to approve",
+                    },
+                },
+                "required": ["episode_id", "step_name"],
+            },
+            annotations=ToolAnnotations(destructiveHint=False, readOnlyHint=False),
+        ),
+        Tool(
+            name="reject_step",
+            description="Reject a completed pipeline step (status must be needs_approval). The step can be re-run after rejection.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "episode_id": {"type": "integer", "description": "Episode ID"},
+                    "step_name": {
+                        "type": "string",
+                        "enum": STEP_NAMES,
+                        "description": "Pipeline step to reject",
+                    },
+                    "reason": {"type": "string", "description": "Rejection reason"},
+                },
+                "required": ["episode_id", "step_name", "reason"],
+            },
+            annotations=ToolAnnotations(destructiveHint=False, readOnlyHint=False),
+        ),
+        Tool(
+            name="get_step_detail",
+            description="Get detailed input/output data for a specific pipeline step. Useful for reviewing step results before approval.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "episode_id": {"type": "integer", "description": "Episode ID"},
+                    "step_name": {
+                        "type": "string",
+                        "enum": STEP_NAMES,
+                        "description": "Pipeline step name",
+                    },
+                },
+                "required": ["episode_id", "step_name"],
+            },
+            annotations=ToolAnnotations(readOnlyHint=True),
+        ),
+        # ---- Research ----
+        Tool(
+            name="search_news",
+            description=(
+                "Search for news articles using Brave Search. "
+                "Returns titles, URLs, descriptions, and age. "
+                "Use the results to select articles for create_episode_from_articles."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Search query (supports Japanese)"},
+                    "count": {
+                        "type": "integer",
+                        "description": "Number of results (default: 10, max: 20)",
+                        "default": 10,
+                    },
+                    "freshness": {
+                        "type": "string",
+                        "enum": ["pd", "pw", "pm"],
+                        "description": "Time filter: pd=past day, pw=past week, pm=past month",
+                    },
+                },
+                "required": ["query"],
+            },
+            annotations=ToolAnnotations(readOnlyHint=True),
+        ),
+        # ---- Observability ----
+        Tool(
+            name="get_cost_stats",
+            description="Get API cost statistics aggregated by provider and pipeline step.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "from_date": {"type": "string", "description": "Start date (YYYY-MM-DD)"},
+                    "to_date": {"type": "string", "description": "End date (YYYY-MM-DD)"},
+                    "episode_id": {"type": "integer", "description": "Filter by episode ID"},
+                },
+            },
+            annotations=ToolAnnotations(readOnlyHint=True),
+        ),
+        Tool(
+            name="health_check",
+            description="Check if the AI News Radio backend is running and responsive.",
+            inputSchema={"type": "object", "properties": {}},
+            annotations=ToolAnnotations(readOnlyHint=True),
+        ),
+    ]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "anthropic>=0.43",
     "openai>=1.60",
     "google-generativeai>=0.8",
+    "mcp>=1.18.0",
     "pydantic-settings>=2.7",
     "beautifulsoup4>=4.12",
 ]

--- a/backend/tests/test_mcp_tools.py
+++ b/backend/tests/test_mcp_tools.py
@@ -1,0 +1,448 @@
+"""Tests for MCP server tools, client, and response formatting."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcp_server.client import AINewsRadioClient, APIError
+from mcp_server.server import _dispatch
+from mcp_server.tools import STEP_NAMES, get_tool_definitions
+
+
+class TestToolDefinitions:
+    """Validate MCP tool definitions."""
+
+    def test_tool_count(self):
+        tools = get_tool_definitions()
+        assert len(tools) == 11
+
+    def test_tool_names(self):
+        tools = get_tool_definitions()
+        names = {t.name for t in tools}
+        expected = {
+            "create_episode",
+            "create_episode_from_articles",
+            "list_episodes",
+            "get_episode_status",
+            "run_step",
+            "approve_step",
+            "reject_step",
+            "get_step_detail",
+            "search_news",
+            "get_cost_stats",
+            "health_check",
+        }
+        assert names == expected
+
+    def test_all_tools_have_input_schema(self):
+        tools = get_tool_definitions()
+        for tool in tools:
+            assert tool.inputSchema is not None
+            assert tool.inputSchema["type"] == "object"
+
+    def test_required_fields(self):
+        tools = get_tool_definitions()
+        tool_map = {t.name: t for t in tools}
+
+        # create_episode requires title
+        assert tool_map["create_episode"].inputSchema["required"] == ["title"]
+
+        # run_step requires episode_id and step_name
+        assert set(tool_map["run_step"].inputSchema["required"]) == {"episode_id", "step_name"}
+
+        # reject_step requires reason
+        assert "reason" in tool_map["reject_step"].inputSchema["required"]
+
+        # search_news requires query
+        assert tool_map["search_news"].inputSchema["required"] == ["query"]
+
+    def test_step_names_enum_in_run_step(self):
+        tools = get_tool_definitions()
+        tool_map = {t.name: t for t in tools}
+        run_step = tool_map["run_step"]
+        step_enum = run_step.inputSchema["properties"]["step_name"]["enum"]
+        assert step_enum == STEP_NAMES
+
+    def test_annotations_present(self):
+        tools = get_tool_definitions()
+        for tool in tools:
+            assert tool.annotations is not None
+
+    def test_readonly_tools(self):
+        tools = get_tool_definitions()
+        tool_map = {t.name: t for t in tools}
+        readonly_tools = [
+            "list_episodes",
+            "get_episode_status",
+            "get_step_detail",
+            "search_news",
+            "get_cost_stats",
+            "health_check",
+        ]
+        for name in readonly_tools:
+            assert tool_map[name].annotations.readOnlyHint is True
+
+
+class TestClient:
+    """Test AINewsRadioClient HTTP calls."""
+
+    @pytest.fixture
+    def api_client(self):
+        return AINewsRadioClient(base_url="http://test:8000")
+
+    async def test_health(self, api_client):
+        with patch.object(api_client, "_request", new_callable=AsyncMock) as mock:
+            mock.return_value = {"status": "ok"}
+            result = await api_client.health()
+            mock.assert_called_once_with("GET", "/api/health")
+            assert result == {"status": "ok"}
+
+    async def test_create_episode(self, api_client):
+        with patch.object(api_client, "_request", new_callable=AsyncMock) as mock:
+            mock.return_value = {"id": 1, "title": "Test", "status": "draft", "pipeline_steps": []}
+            result = await api_client.create_episode("Test")
+            mock.assert_called_once_with("POST", "/api/episodes", json={"title": "Test"})
+            assert result["id"] == 1
+
+    async def test_create_episode_from_articles(self, api_client):
+        articles = [{"title": "A", "source_url": "http://a.com", "source_name": "A"}]
+        with patch.object(api_client, "_request", new_callable=AsyncMock) as mock:
+            mock.return_value = {"id": 1, "title": "Test", "status": "in_progress", "pipeline_steps": []}
+            await api_client.create_episode_from_articles("Test", articles)
+            mock.assert_called_once_with(
+                "POST", "/api/episodes/from-articles", json={"title": "Test", "articles": articles}
+            )
+
+    async def test_list_episodes(self, api_client):
+        with patch.object(api_client, "_request", new_callable=AsyncMock) as mock:
+            mock.return_value = {"episodes": [], "total": 0}
+            result = await api_client.list_episodes()
+            mock.assert_called_once_with("GET", "/api/episodes")
+            assert result["total"] == 0
+
+    async def test_run_step(self, api_client):
+        with patch.object(api_client, "_request", new_callable=AsyncMock) as mock:
+            mock.return_value = {"id": 1, "step_name": "collection", "status": "running"}
+            await api_client.run_step(1, "collection")
+            mock.assert_called_once_with("POST", "/api/episodes/1/steps/collection/run", json={})
+
+    async def test_run_step_with_queries(self, api_client):
+        with patch.object(api_client, "_request", new_callable=AsyncMock) as mock:
+            mock.return_value = {"id": 1, "step_name": "collection", "status": "running"}
+            await api_client.run_step(1, "collection", queries=["熊本 ニュース"])
+            mock.assert_called_once_with(
+                "POST", "/api/episodes/1/steps/collection/run", json={"queries": ["熊本 ニュース"]}
+            )
+
+    async def test_approve_step(self, api_client):
+        with patch.object(api_client, "_request", new_callable=AsyncMock) as mock:
+            mock.return_value = {"id": 5, "step_name": "collection", "status": "approved"}
+            await api_client.approve_step(5)
+            mock.assert_called_once_with("POST", "/api/steps/5/approve")
+
+    async def test_reject_step(self, api_client):
+        with patch.object(api_client, "_request", new_callable=AsyncMock) as mock:
+            mock.return_value = {"id": 5, "step_name": "collection", "status": "rejected"}
+            await api_client.reject_step(5, "Bad quality")
+            mock.assert_called_once_with("POST", "/api/steps/5/reject", json={"reason": "Bad quality"})
+
+    async def test_resolve_step_id(self, api_client):
+        with patch.object(api_client, "get_steps", new_callable=AsyncMock) as mock:
+            mock.return_value = [
+                {"id": 10, "step_name": "collection", "status": "approved"},
+                {"id": 11, "step_name": "factcheck", "status": "pending"},
+            ]
+            step_id = await api_client.resolve_step_id(1, "factcheck")
+            assert step_id == 11
+
+    async def test_resolve_step_id_not_found(self, api_client):
+        with patch.object(api_client, "get_steps", new_callable=AsyncMock) as mock:
+            mock.return_value = [{"id": 10, "step_name": "collection", "status": "approved"}]
+            with pytest.raises(APIError, match="not found"):
+                await api_client.resolve_step_id(1, "nonexistent")
+
+    async def test_get_cost_stats(self, api_client):
+        with patch.object(api_client, "_request", new_callable=AsyncMock) as mock:
+            mock.return_value = {"total_cost_usd": 0.5, "total_requests": 10, "by_provider": [], "by_step": []}
+            await api_client.get_cost_stats("2026-01-01", "2026-03-01")
+            mock.assert_called_once_with(
+                "GET", "/api/stats/costs", params={"from": "2026-01-01", "to": "2026-03-01"}
+            )
+
+    async def test_search_news(self, api_client):
+        with patch.object(api_client, "_request", new_callable=AsyncMock) as mock:
+            mock.return_value = [{"title": "News", "url": "http://test.com", "description": "Desc", "age": "1h"}]
+            await api_client.search_news("熊本", count=5, freshness="pd")
+            mock.assert_called_once_with(
+                "GET", "/api/search/news", params={"q": "熊本", "count": 5, "freshness": "pd"}
+            )
+
+
+class TestDispatch:
+    """Test server dispatch and response formatting."""
+
+    async def test_health_check(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.health = AsyncMock(return_value={"status": "ok"})
+            result = await _dispatch("health_check", {})
+            assert "ok" in result
+
+    async def test_create_episode(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.create_episode = AsyncMock(
+                return_value={
+                    "id": 1,
+                    "title": "Test Episode",
+                    "status": "draft",
+                    "pipeline_steps": [
+                        {"step_name": "collection", "status": "pending"},
+                        {"step_name": "factcheck", "status": "pending"},
+                    ],
+                }
+            )
+            result = await _dispatch("create_episode", {"title": "Test Episode"})
+            assert "Episode #1 created" in result
+            assert "Test Episode" in result
+            assert "collection" in result
+
+    async def test_list_episodes_empty(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.list_episodes = AsyncMock(return_value={"episodes": [], "total": 0})
+            result = await _dispatch("list_episodes", {})
+            assert "No episodes found" in result
+
+    async def test_list_episodes(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.list_episodes = AsyncMock(
+                return_value={
+                    "episodes": [
+                        {
+                            "id": 1,
+                            "title": "Ep 1",
+                            "status": "in_progress",
+                            "pipeline_steps": [
+                                {"step_name": "collection", "status": "approved"},
+                                {"step_name": "factcheck", "status": "running"},
+                            ],
+                        }
+                    ],
+                    "total": 1,
+                }
+            )
+            result = await _dispatch("list_episodes", {})
+            assert "#1" in result
+            assert "Ep 1" in result
+            assert "in_progress" in result
+
+    async def test_get_episode_status(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.get_episode = AsyncMock(
+                return_value={
+                    "id": 1,
+                    "title": "Test",
+                    "status": "in_progress",
+                    "created_at": "2026-03-09T00:00:00",
+                    "pipeline_steps": [
+                        {"step_name": "collection", "status": "approved", "started_at": "t1", "completed_at": "t2", "rejection_reason": None},
+                    ],
+                }
+            )
+            mock_client.get_news_items = AsyncMock(
+                return_value=[
+                    {
+                        "title": "News 1",
+                        "source_name": "NHK",
+                        "source_url": "http://nhk.or.jp/1",
+                        "fact_check_score": 4,
+                        "script_text": None,
+                    }
+                ]
+            )
+            result = await _dispatch("get_episode_status", {"episode_id": 1})
+            assert "Episode #1" in result
+            assert "collection" in result
+            assert "[v]" in result
+            assert "News 1" in result
+            assert "fact-check: 4/5" in result
+
+    async def test_run_step(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.run_step = AsyncMock(
+                return_value={"id": 1, "step_name": "collection", "status": "running"}
+            )
+            result = await _dispatch("run_step", {"episode_id": 1, "step_name": "collection"})
+            assert "started" in result
+            assert "get_episode_status" in result
+
+    async def test_approve_step(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.resolve_step_id = AsyncMock(return_value=5)
+            mock_client.approve_step = AsyncMock(
+                return_value={"id": 5, "step_name": "collection", "status": "approved"}
+            )
+            result = await _dispatch("approve_step", {"episode_id": 1, "step_name": "collection"})
+            assert "approved" in result
+            assert "factcheck" in result  # next step hint
+
+    async def test_approve_last_step(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.resolve_step_id = AsyncMock(return_value=7)
+            mock_client.approve_step = AsyncMock(
+                return_value={"id": 7, "step_name": "publish", "status": "approved"}
+            )
+            result = await _dispatch("approve_step", {"episode_id": 1, "step_name": "publish"})
+            assert "final step" in result
+
+    async def test_reject_step(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.resolve_step_id = AsyncMock(return_value=5)
+            mock_client.reject_step = AsyncMock(
+                return_value={"id": 5, "step_name": "factcheck", "status": "rejected"}
+            )
+            result = await _dispatch("reject_step", {"episode_id": 1, "step_name": "factcheck", "reason": "Low quality"})
+            assert "rejected" in result
+            assert "Low quality" in result
+
+    async def test_search_news(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.search_news = AsyncMock(
+                return_value=[
+                    {"title": "熊本ニュース1", "url": "http://example.com/1", "description": "Description 1", "age": "2h"},
+                    {"title": "熊本ニュース2", "url": "http://example.com/2", "description": "Description 2", "age": None},
+                ]
+            )
+            result = await _dispatch("search_news", {"query": "熊本"})
+            assert "熊本ニュース1" in result
+            assert "http://example.com/1" in result
+            assert "2 results" in result
+
+    async def test_search_news_empty(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.search_news = AsyncMock(return_value=[])
+            result = await _dispatch("search_news", {"query": "nonexistent"})
+            assert "No results" in result
+
+    async def test_get_cost_stats(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.get_cost_stats = AsyncMock(
+                return_value={
+                    "total_cost_usd": 1.2345,
+                    "total_requests": 42,
+                    "by_provider": [{"provider": "anthropic", "total_cost_usd": 1.0, "request_count": 30}],
+                    "by_step": [{"step_name": "factcheck", "total_cost_usd": 0.5, "request_count": 10}],
+                }
+            )
+            result = await _dispatch("get_cost_stats", {})
+            assert "$1.2345" in result
+            assert "42 requests" in result
+            assert "anthropic" in result
+            assert "factcheck" in result
+
+    async def test_get_cost_stats_by_episode(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.get_episode_cost = AsyncMock(
+                return_value={
+                    "episode_id": 1,
+                    "total_cost_usd": 0.5,
+                    "total_requests": 10,
+                    "by_provider": [],
+                    "by_step": [],
+                }
+            )
+            result = await _dispatch("get_cost_stats", {"episode_id": 1})
+            assert "Episode #1" in result
+            assert "$0.5000" in result
+
+    async def test_get_step_detail(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.get_steps = AsyncMock(
+                return_value=[
+                    {
+                        "step_name": "collection",
+                        "status": "needs_approval",
+                        "started_at": "2026-03-09T01:00:00",
+                        "completed_at": "2026-03-09T01:05:00",
+                        "input_data": {"queries": ["熊本"]},
+                        "output_data": {"articles_found": 5},
+                        "rejection_reason": None,
+                    }
+                ]
+            )
+            result = await _dispatch("get_step_detail", {"episode_id": 1, "step_name": "collection"})
+            assert "collection" in result
+            assert "needs_approval" in result
+            assert "熊本" in result
+            assert "articles_found" in result
+
+    async def test_get_step_detail_not_found(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.get_steps = AsyncMock(return_value=[])
+            result = await _dispatch("get_step_detail", {"episode_id": 1, "step_name": "collection"})
+            assert "not found" in result
+
+    async def test_unknown_tool(self):
+        result = await _dispatch("nonexistent_tool", {})
+        assert "Unknown tool" in result
+
+
+class TestErrorHandling:
+    """Test error handling in dispatch."""
+
+    async def test_api_error_returned_as_text(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.health = AsyncMock(side_effect=APIError(500, "Internal Server Error"))
+            from mcp_server.server import call_tool
+
+            result = await call_tool("health_check", {})
+            assert len(result) == 1
+            assert "Internal Server Error" in result[0].text
+
+    async def test_unexpected_error(self):
+        with patch("mcp_server.server.client") as mock_client:
+            mock_client.health = AsyncMock(side_effect=RuntimeError("unexpected"))
+            from mcp_server.server import call_tool
+
+            result = await call_tool("health_check", {})
+            assert len(result) == 1
+            assert "unexpected" in result[0].text
+
+
+class TestSearchAPI:
+    """Test the search API endpoint via FastAPI test client."""
+
+    async def test_search_news_endpoint(self, client):
+        with patch("app.api.search.BraveSearchService") as mock_cls:
+            mock_service = AsyncMock()
+            mock_cls.return_value = mock_service
+
+            from app.services.brave_search import BraveSearchResult
+
+            mock_service.web_search.return_value = [
+                BraveSearchResult(title="Test", url="http://test.com", description="Desc", age="1h")
+            ]
+
+            response = await client.get("/api/search/news", params={"q": "test", "count": 5})
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data) == 1
+            assert data[0]["title"] == "Test"
+            assert data[0]["url"] == "http://test.com"
+            mock_service.web_search.assert_called_once_with(query="test", count=5, freshness=None)
+
+    async def test_search_news_missing_query(self, client):
+        response = await client.get("/api/search/news")
+        assert response.status_code == 422
+
+    async def test_search_news_with_freshness(self, client):
+        with patch("app.api.search.BraveSearchService") as mock_cls:
+            mock_service = AsyncMock()
+            mock_cls.return_value = mock_service
+            mock_service.web_search.return_value = []
+
+            response = await client.get("/api/search/news", params={"q": "test", "freshness": "pd"})
+            assert response.status_code == 200
+            mock_service.web_search.assert_called_once_with(query="test", count=10, freshness="pd")
+
+    async def test_search_news_invalid_freshness(self, client):
+        response = await client.get("/api/search/news", params={"q": "test", "freshness": "invalid"})
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary

- Claude Code から AI News Radio の全操作を実行可能にする MCP サーバーを追加
- stdio トランスポートで FastAPI バックエンドに httpx 経由でリクエストを送る独立パッケージ
- 11 MCP ツール、Brave Search API エンドポイント、41 テスト

## MCP ツール一覧

| カテゴリ | ツール | 説明 |
|---------|--------|------|
| Episode | `create_episode` | エピソード作成 |
| Episode | `create_episode_from_articles` | 記事直接入力でエピソード作成 |
| Episode | `list_episodes` | エピソード一覧 |
| Pipeline | `get_episode_status` | ステップ状態 + ニュース一覧 |
| Pipeline | `run_step` | ステップ実行（非同期） |
| Pipeline | `approve_step` | ステップ承認 |
| Pipeline | `reject_step` | ステップ却下 |
| Pipeline | `get_step_detail` | ステップ入出力データ詳細 |
| Research | `search_news` | Brave Search でニュース検索 |
| Observability | `get_cost_stats` | コスト統計 |
| Observability | `health_check` | バックエンド疎通確認 |

## ファイル構成

```
backend/mcp_server/
  __init__.py    # パッケージマーカー
  __main__.py    # エントリポイント: python -m mcp_server
  config.py      # BACKEND_URL, REQUEST_TIMEOUT
  client.py      # httpx API クライアント
  tools.py       # 11 ツール定義（inputSchema + annotations）
  server.py      # list_tools/call_tool ハンドラ + レスポンス整形
```

## その他の変更

- `GET /api/search/news` エンドポイント新設（BraveSearchService）
- `.mcp.json.example` をサンプルとして同梱
- `.mcp.json` を `.gitignore` に追加（認証トークン・ローカルパス保護）
- `backend/media/`, `frontend/.vite/`, `frontend/tsconfig.tsbuildinfo` も `.gitignore` に追加

## Test plan

- [x] `pytest tests/test_mcp_tools.py -v` — 41 テスト全パス
- [x] `python -m mcp_server` で起動確認
- [x] Claude Code から `/mcp` で接続確認
- [x] `health_check`, `list_episodes`, `search_news`, `get_episode_status`, `get_cost_stats`, `get_step_detail` の動作確認済み

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)