### PR TITLE
feat: YouTube メタデータ自動生成 (#50)

### DIFF
--- a/backend/app/pipeline/video.py
+++ b/backend/app/pipeline/video.py
@@ -9,8 +9,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
-from app.models import Episode, PipelineStep, StepName
+from app.models import Episode, NewsItem, PipelineStep, StepName
 from app.pipeline.base import BaseStep
+from app.pipeline.utils import parse_json_response
+from app.services.ai_provider import get_step_provider
 from app.services.visual_provider import get_visual_provider
 
 logger = logging.getLogger(__name__)
@@ -93,14 +95,25 @@ class VideoStep(BaseStep):
                 cost_usd=0.04 * images_generated,  # Imagen 4 Fast: ~$0.04/image
             )
 
-        # Compose video
-        await self._generate_video(
+        # Run FFmpeg encoding and YouTube metadata generation in parallel
+        news_items = await self._get_news_items(episode_id, session)
+
+        video_task = self._generate_video(
             audio_path=audio_full_path,
             video_path=video_path,
             bg_image_path=bg_image_path,
             script_text=script_text,
             duration_seconds=duration_seconds,
         )
+        metadata_task = self._generate_youtube_metadata(
+            episode=episode,
+            news_items=news_items,
+            script_text=script_text,
+            duration_seconds=duration_seconds,
+            session=session,
+        )
+
+        _, youtube_metadata = await asyncio.gather(video_task, metadata_task)
 
         # Update episode record
         relative_path = f"{episode_id}/video.mp4"
@@ -116,8 +129,87 @@ class VideoStep(BaseStep):
         }
         if thumbnail_relative:
             result["thumbnail_path"] = thumbnail_relative
+        if youtube_metadata:
+            result["youtube_metadata"] = youtube_metadata
 
         return result
+
+    async def _generate_youtube_metadata(
+        self,
+        episode: Episode,
+        news_items: list[NewsItem],
+        script_text: str,
+        duration_seconds: float,
+        session: AsyncSession,
+    ) -> dict | None:
+        """Generate YouTube metadata (title, description, tags) using AI."""
+        try:
+            provider, model = get_step_provider("script")  # Reuse script step's AI config
+
+            news_summary = "\n".join(f"- {item.title}" for item in news_items)
+            duration_min = int(duration_seconds // 60)
+            duration_sec = int(duration_seconds % 60)
+
+            prompt = (
+                f"番組タイトル: {episode.title}\n"
+                f"ニュース一覧:\n{news_summary}\n"
+                f"動画の長さ: {duration_min}分{duration_sec}秒\n\n"
+                f"台本の冒頭300文字:\n{script_text[:300]}"
+            )
+
+            system = """\
+あなたはYouTubeのSEO・アルゴリズム最適化の専門家です。
+ニュースラジオ番組の動画に最適なメタデータを生成してください。
+
+## ルール
+
+### title（60文字以内）
+- 検索されやすいキーワードを自然に含める
+- クリックベイトにならない範囲で興味を引く
+- 【】で主要トピックを冒頭に
+
+### description（日本語、2000文字以内）
+- 冒頭3行で要点（折りたたみ前に表示される部分が重要）
+- ⏱ タイムスタンプ（0:00 オープニング、おおよそのセクション位置）
+- 📌 ニュース一覧
+- 関連キーワードを自然に含める
+- 末尾にクレジット: 🎙 音声: VOICEVOX / 📻 AI News Radio Japan
+
+### tags（配列、合計500文字以内）
+- ニュース関連キーワード
+- 地域名・トピック固有のタグ
+- 日本語と英語を混ぜる
+- 15-25個程度
+
+以下のJSON形式で回答してください。JSON以外のテキストは含めないでください:
+{
+  "title": "動画タイトル",
+  "description": "概要文",
+  "tags": ["タグ1", "タグ2", ...]
+}"""
+
+            response = await provider.generate(prompt=prompt, model=model, system=system)
+            data = parse_json_response(response.content)
+
+            await self.record_usage(
+                session=session,
+                episode_id=episode.id,
+                provider=response.provider,
+                model=response.model,
+                input_tokens=response.input_tokens,
+                output_tokens=response.output_tokens,
+            )
+
+            logger.info("Episode %d: YouTube metadata generated", episode.id)
+            return {
+                "title": data.get("title", ""),
+                "description": data.get("description", ""),
+                "tags": data.get("tags", []),
+            }
+
+        except Exception as e:
+            logger.warning("YouTube metadata generation failed: %s", e)
+            return None
 
     async def _get_script_step_output(self, episode_id: int, session: AsyncSession) -> dict:
         """Get the script pipeline step's output_data."""

--- a/frontend/src/components/step-renderers/StepDataRenderer.tsx
+++ b/frontend/src/components/step-renderers/StepDataRenderer.tsx
@@ -3,6 +3,7 @@ import CollectionRenderer from "./CollectionRenderer";
 import FactcheckRenderer from "./FactcheckRenderer";
 import AnalysisRenderer from "./AnalysisRenderer";
 import ScriptRenderer from "./ScriptRenderer";
+import VideoRenderer from "./VideoRenderer";
 
 interface Props {
   stepName: StepName;
@@ -40,6 +41,8 @@ export default function StepDataRenderer({
           onUpdated={onUpdated}
         />
       );
+    case "video":
+      return <VideoRenderer outputData={outputData} />;
     default:
       return (
         <pre className="p-3 bg-gray-50 rounded border text-xs overflow-auto max-h-64">

--- a/frontend/src/components/step-renderers/VideoRenderer.tsx
+++ b/frontend/src/components/step-renderers/VideoRenderer.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface YouTubeMetadata {
+  title?: string;
+  description?: string;
+  tags?: string[];
+}
+
+interface Props {
+  outputData: Record<string, unknown>;
+}
+
+function CopyButton({ text, label }: { text: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="text-xs text-blue-600 hover:text-blue-800 cursor-pointer"
+    >
+      {copied ? "✓" : label}
+    </button>
+  );
+}
+
+export default function VideoRenderer({ outputData }: Props) {
+  const { t } = useTranslation();
+  const metadata = outputData.youtube_metadata as YouTubeMetadata | undefined;
+
+  if (!metadata) return null;
+
+  return (
+    <div className="space-y-4">
+      <h4 className="text-sm font-medium text-gray-600">
+        {t("stepData.video.youtubeMetadata")}
+      </h4>
+
+      {metadata.title && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-xs font-medium text-gray-500">
+              {t("stepData.video.title")}
+            </p>
+            <CopyButton text={metadata.title} label={t("stepData.video.copy")} />
+          </div>
+          <p className="text-sm text-gray-800 bg-gray-50 rounded p-2 border">
+            {metadata.title}
+          </p>
+        </div>
+      )}
+
+      {metadata.description && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-xs font-medium text-gray-500">
+              {t("stepData.video.description")}
+            </p>
+            <CopyButton text={metadata.description} label={t("stepData.video.copy")} />
+          </div>
+          <pre className="text-sm text-gray-800 bg-gray-50 rounded p-3 border whitespace-pre-wrap max-h-64 overflow-y-auto">
+            {metadata.description}
+          </pre>
+        </div>
+      )}
+
+      {metadata.tags && metadata.tags.length > 0 && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-xs font-medium text-gray-500">
+              {t("stepData.video.tags")}
+            </p>
+            <CopyButton text={metadata.tags.join(", ")} label={t("stepData.video.copy")} />
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {metadata.tags.map((tag, i) => (
+              <span
+                key={i}
+                className="px-2 py-0.5 rounded-full text-xs bg-blue-50 text-blue-700"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -146,6 +146,13 @@
       "save": "Save",
       "saving": "Saving...",
       "cancel": "Cancel"
+    },
+    "video": {
+      "youtubeMetadata": "YouTube Metadata",
+      "title": "Title",
+      "description": "Description",
+      "tags": "Tags",
+      "copy": "Copy"
     }
   },
   "settings": {

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -146,6 +146,13 @@
       "save": "保存",
       "saving": "保存中...",
       "cancel": "キャンセル"
+    },
+    "video": {
+      "youtubeMetadata": "YouTube メタデータ",
+      "title": "タイトル",
+      "description": "概要文",
+      "tags": "タグ",
+      "copy": "コピー"
     }
   },
   "settings": {


### PR DESCRIPTION
## Summary

video ステップで YouTube アップロード用のメタデータ（タイトル・概要文・タグ）を AI で自動生成。

### 実装

- FFmpeg エンコードと `asyncio.gather` で並行して LLM を呼び出し
- SEO 考慮: 検索キーワード、冒頭3行の要点、タイムスタンプ、ハッシュタグ
- `output_data.youtube_metadata` に `title`, `description`, `tags` を格納
- VideoRenderer: プレビュー表示 + ワンクリックコピーボタン
- メタデータ生成失敗時は `null`（動画生成には影響しない）

### WebUI

video ステップの承認画面で:
- タイトル（コピーボタン付き）
- 概要文（コピーボタン付き）
- タグ一覧（コピーボタン付き）

## Test plan

- [x] `pytest` — 121 テスト全パス
- [x] `npm run build` — フロントエンドビルド成功

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)