### PR TITLE
feat: WebUIからプロンプトテンプレートを編集可能にする

### DIFF
--- a/backend/alembic/versions/009_add_prompt_templates.py
+++ b/backend/alembic/versions/009_add_prompt_templates.py
@@ -1,0 +1,32 @@
+"""Add prompt_templates table
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-03-10
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "009"
+down_revision = "008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "prompt_templates",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("key", sa.String(100), nullable=False, index=True),
+        sa.Column("name", sa.String(200), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("prompt_templates")

--- a/backend/app/api/prompts.py
+++ b/backend/app/api/prompts.py
@@ -1,0 +1,206 @@
+"""API endpoints for managing prompt templates."""
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.pipeline.analyzer  # noqa: F401
+
+# Import pipeline modules to register their default prompts
+import app.pipeline.factchecker  # noqa: F401
+import app.pipeline.scriptwriter  # noqa: F401
+import app.pipeline.video  # noqa: F401
+from app.database import get_session
+from app.models.prompt_template import PromptTemplate
+from app.services.prompt_loader import get_all_defaults
+
+router = APIRouter()
+
+# Display names for prompt keys
+PROMPT_NAMES: dict[str, str] = {
+    "factcheck": "ファクトチェック",
+    "analysis": "クリティカル分析",
+    "script_item": "台本生成（個別記事）",
+    "script_episode": "台本生成（エピソード構成）",
+    "youtube_metadata": "YouTube メタデータ",
+}
+
+
+class PromptTemplateResponse(BaseModel):
+    id: int
+    key: str
+    name: str
+    content: str
+    version: int
+    is_active: bool
+    created_at: str
+    updated_at: str
+
+
+class PromptSummaryResponse(BaseModel):
+    key: str
+    name: str
+    active_version: int | None
+    has_custom: bool
+    content_preview: str
+
+
+class PromptUpdateRequest(BaseModel):
+    content: str
+
+
+class PromptHistoryResponse(BaseModel):
+    key: str
+    name: str
+    default_content: str
+    active_version: int | None
+    versions: list[PromptTemplateResponse]
+
+
+def _to_response(t: PromptTemplate) -> PromptTemplateResponse:
+    return PromptTemplateResponse(
+        id=t.id,
+        key=t.key,
+        name=t.name,
+        content=t.content,
+        version=t.version,
+        is_active=t.is_active,
+        created_at=t.created_at.isoformat(),
+        updated_at=t.updated_at.isoformat(),
+    )
+
+
+@router.get("/prompts", response_model=list[PromptSummaryResponse])
+async def list_prompts(session: AsyncSession = Depends(get_session)):
+    """List all prompt templates (one entry per key) with active version info."""
+    defaults = get_all_defaults()
+
+    # Get all active templates
+    result = await session.execute(
+        select(PromptTemplate).where(PromptTemplate.is_active == True).order_by(  # noqa: E712
+            PromptTemplate.key
+        )
+    )
+    active_templates = {t.key: t for t in result.scalars().all()}
+
+    summaries = []
+    for key in PROMPT_NAMES:
+        name = PROMPT_NAMES[key]
+        template = active_templates.get(key)
+        content = template.content if template else defaults.get(key, "")
+        summaries.append(
+            PromptSummaryResponse(
+                key=key,
+                name=name,
+                active_version=template.version if template else None,
+                has_custom=template is not None,
+                content_preview=content[:100] + "..." if len(content) > 100 else content,
+            )
+        )
+
+    return summaries
+
+
+@router.get("/prompts/{key}", response_model=PromptHistoryResponse)
+async def get_prompt(key: str, session: AsyncSession = Depends(get_session)):
+    """Get a prompt template with full version history."""
+    if key not in PROMPT_NAMES:
+        raise HTTPException(status_code=404, detail=f"Unknown prompt key: {key}")
+
+    defaults = get_all_defaults()
+
+    result = await session.execute(
+        select(PromptTemplate).where(PromptTemplate.key == key).order_by(PromptTemplate.version.desc())
+    )
+    versions = [_to_response(t) for t in result.scalars().all()]
+
+    active_version = None
+    for v in versions:
+        if v.is_active:
+            active_version = v.version
+            break
+
+    return PromptHistoryResponse(
+        key=key,
+        name=PROMPT_NAMES[key],
+        default_content=defaults.get(key, ""),
+        active_version=active_version,
+        versions=versions,
+    )
+
+
+@router.put("/prompts/{key}", response_model=PromptTemplateResponse)
+async def update_prompt(key: str, body: PromptUpdateRequest, session: AsyncSession = Depends(get_session)):
+    """Update a prompt template (creates a new version)."""
+    if key not in PROMPT_NAMES:
+        raise HTTPException(status_code=404, detail=f"Unknown prompt key: {key}")
+
+    # Get current max version
+    result = await session.execute(
+        select(PromptTemplate.version).where(PromptTemplate.key == key).order_by(
+            PromptTemplate.version.desc()
+        ).limit(1)
+    )
+    max_version = result.scalar_one_or_none() or 0
+
+    # Deactivate all existing versions for this key
+    await session.execute(
+        update(PromptTemplate).where(PromptTemplate.key == key).values(is_active=False)
+    )
+
+    # Create new version
+    new_template = PromptTemplate(
+        key=key,
+        name=PROMPT_NAMES[key],
+        content=body.content,
+        version=max_version + 1,
+        is_active=True,
+        updated_at=datetime.now(UTC),
+    )
+    session.add(new_template)
+    await session.commit()
+    await session.refresh(new_template)
+
+    return _to_response(new_template)
+
+
+@router.post("/prompts/{key}/rollback/{version}", response_model=PromptTemplateResponse)
+async def rollback_prompt(key: str, version: int, session: AsyncSession = Depends(get_session)):
+    """Rollback to a specific version (makes it active, deactivates others)."""
+    if key not in PROMPT_NAMES:
+        raise HTTPException(status_code=404, detail=f"Unknown prompt key: {key}")
+
+    result = await session.execute(
+        select(PromptTemplate).where(PromptTemplate.key == key, PromptTemplate.version == version)
+    )
+    target = result.scalar_one_or_none()
+    if not target:
+        raise HTTPException(status_code=404, detail=f"Version {version} not found for key: {key}")
+
+    # Deactivate all versions
+    await session.execute(
+        update(PromptTemplate).where(PromptTemplate.key == key).values(is_active=False)
+    )
+
+    # Activate the target version
+    target.is_active = True
+    target.updated_at = datetime.now(UTC)
+    await session.commit()
+    await session.refresh(target)
+
+    return _to_response(target)
+
+
+@router.delete("/prompts/{key}", status_code=204)
+async def reset_prompt(key: str, session: AsyncSession = Depends(get_session)):
+    """Reset to default by deactivating all custom versions."""
+    if key not in PROMPT_NAMES:
+        raise HTTPException(status_code=404, detail=f"Unknown prompt key: {key}")
+
+    await session.execute(
+        update(PromptTemplate).where(PromptTemplate.key == key).values(is_active=False)
+    )
+    await session.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from app.api.episodes import router as episodes_router
 from app.api.health import router as health_router
 from app.api.pipeline import router as pipeline_router
 from app.api.pricing import router as pricing_router
+from app.api.prompts import router as prompts_router
 from app.api.search import router as search_router
 from app.api.stats import router as stats_router
 from app.config import settings
@@ -36,4 +37,5 @@ app.include_router(pipeline_router, prefix="/api")
 app.include_router(stats_router, prefix="/api")
 app.include_router(pricing_router, prefix="/api")
 app.include_router(search_router, prefix="/api")
+app.include_router(prompts_router, prefix="/api")
 app.include_router(dictionary_router, prefix="/api")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.episode import Episode, EpisodeStatus
 from app.models.model_pricing import ModelPricing
 from app.models.news_item import NewsItem
 from app.models.pipeline_step import PipelineStep, StepName, StepStatus
+from app.models.prompt_template import PromptTemplate
 from app.models.pronunciation import Pronunciation
 
 __all__ = [
@@ -14,6 +15,7 @@ __all__ = [
     "ModelPricing",
     "NewsItem",
     "PipelineStep",
+    "PromptTemplate",
     "Pronunciation",
     "StepName",
     "StepStatus",

--- a/backend/app/models/prompt_template.py
+++ b/backend/app/models/prompt_template.py
@@ -1,0 +1,21 @@
+"""Prompt template model for managing AI prompts via WebUI."""
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class PromptTemplate(Base):
+    __tablename__ = "prompt_templates"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    key: Mapped[str] = mapped_column(String(100), index=True)
+    name: Mapped[str] = mapped_column(String(200))
+    content: Mapped[str] = mapped_column(Text)
+    version: Mapped[int] = mapped_column(Integer, default=1)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/pipeline/analyzer.py
+++ b/backend/app/pipeline/analyzer.py
@@ -8,8 +8,11 @@ from app.models import NewsItem, StepName
 from app.pipeline.base import BaseStep
 from app.pipeline.utils import parse_json_response
 from app.services.ai_provider import get_step_provider
+from app.services.prompt_loader import get_active_prompt, register_default
 
 logger = logging.getLogger(__name__)
+
+PROMPT_KEY = "analysis"
 
 ANALYSIS_SYSTEM_PROMPT = """\
 あなたはニュースのクリティカル分析を行う専門家です。
@@ -41,6 +44,8 @@ ANALYSIS_SYSTEM_PROMPT = """\
   "topics": ["関連トピックタグ1", "関連トピックタグ2"]
 }"""
 
+register_default(PROMPT_KEY, ANALYSIS_SYSTEM_PROMPT)
+
 
 class AnalyzerStep(BaseStep):
     """Critically analyze news articles using AI."""
@@ -56,6 +61,7 @@ class AnalyzerStep(BaseStep):
         One AI call per article. Idempotent: re-running overwrites previous results.
         """
         provider, model = get_step_provider(self.step_name.value)
+        system_prompt, prompt_version = await get_active_prompt(session, PROMPT_KEY)
         results: list[dict] = []
         total_input_tokens = 0
         total_output_tokens = 0
@@ -63,7 +69,7 @@ class AnalyzerStep(BaseStep):
         items = await self._get_news_items(episode_id, session)
 
         for item in items:
-            result = await self._analyze_item(item, provider, model, session, episode_id)
+            result = await self._analyze_item(item, provider, model, system_prompt, session, episode_id)
             results.append(result)
             total_input_tokens += result["input_tokens"]
             total_output_tokens += result["output_tokens"]
@@ -83,19 +89,23 @@ class AnalyzerStep(BaseStep):
             severity_summary,
         )
 
-        return {
+        result_data: dict = {
             "items_analyzed": len(results),
             "results": results,
             "severity_summary": severity_summary,
             "total_input_tokens": total_input_tokens,
             "total_output_tokens": total_output_tokens,
         }
+        if prompt_version is not None:
+            result_data["prompt_version"] = prompt_version
+        return result_data
 
     async def _analyze_item(
         self,
         item: NewsItem,
         provider,
         model: str,
+        system_prompt: str,
         session: AsyncSession,
         episode_id: int,
     ) -> dict:
@@ -121,7 +131,7 @@ class AnalyzerStep(BaseStep):
         response = await provider.generate(
             prompt=prompt,
             model=model,
-            system=ANALYSIS_SYSTEM_PROMPT,
+            system=system_prompt,
         )
 
         data = parse_json_response(response.content)

--- a/backend/app/pipeline/factchecker.py
+++ b/backend/app/pipeline/factchecker.py
@@ -8,8 +8,11 @@ from app.models import NewsItem, StepName
 from app.pipeline.base import BaseStep
 from app.pipeline.utils import parse_json_response
 from app.services.ai_provider import get_step_provider
+from app.services.prompt_loader import get_active_prompt, register_default
 
 logger = logging.getLogger(__name__)
+
+PROMPT_KEY = "factcheck"
 
 FACTCHECK_SYSTEM_PROMPT = """\
 あなたはニュースのファクトチェックを行う専門家です。
@@ -36,6 +39,8 @@ FACTCHECK_SYSTEM_PROMPT = """\
   ]
 }"""
 
+register_default(PROMPT_KEY, FACTCHECK_SYSTEM_PROMPT)
+
 
 class FactcheckerStep(BaseStep):
     """Fact-check news articles using AI."""
@@ -51,6 +56,7 @@ class FactcheckerStep(BaseStep):
         Idempotent: re-running overwrites previous results.
         """
         provider, model = get_step_provider(self.step_name.value)
+        system_prompt, prompt_version = await get_active_prompt(session, PROMPT_KEY)
         results: list[dict] = []
         total_input_tokens = 0
         total_output_tokens = 0
@@ -58,7 +64,7 @@ class FactcheckerStep(BaseStep):
         items = await self._get_news_items(episode_id, session)
 
         for item in items:
-            result = await self._check_item(item, provider, model, session, episode_id)
+            result = await self._check_item(item, provider, model, system_prompt, session, episode_id)
             results.append(result)
             total_input_tokens += result["input_tokens"]
             total_output_tokens += result["output_tokens"]
@@ -74,13 +80,16 @@ class FactcheckerStep(BaseStep):
             avg_score,
         )
 
-        return {
+        result_data: dict = {
             "items_checked": len(results),
             "results": results,
             "average_score": round(avg_score, 2),
             "total_input_tokens": total_input_tokens,
             "total_output_tokens": total_output_tokens,
         }
+        if prompt_version is not None:
+            result_data["prompt_version"] = prompt_version
+        return result_data
 
     async def _search_references(self, item: NewsItem) -> str:
         """Search for reference material using Brave Search (if available)."""
@@ -112,6 +121,7 @@ class FactcheckerStep(BaseStep):
         item: NewsItem,
         provider,
         model: str,
+        system_prompt: str,
         session: AsyncSession,
         episode_id: int,
     ) -> dict:
@@ -130,7 +140,7 @@ class FactcheckerStep(BaseStep):
         response = await provider.generate(
             prompt=prompt,
             model=model,
-            system=FACTCHECK_SYSTEM_PROMPT,
+            system=system_prompt,
         )
 
         data = parse_json_response(response.content)

--- a/backend/app/pipeline/scriptwriter.py
+++ b/backend/app/pipeline/scriptwriter.py
@@ -9,8 +9,12 @@ from app.models import NewsItem, StepName
 from app.pipeline.base import BaseStep
 from app.pipeline.utils import parse_json_response
 from app.services.ai_provider import get_step_provider
+from app.services.prompt_loader import get_active_prompt, register_default
 
 logger = logging.getLogger(__name__)
+
+PROMPT_KEY_ITEM = "script_item"
+PROMPT_KEY_EPISODE = "script_episode"
 
 SCRIPT_ITEM_SYSTEM_PROMPT = """\
 あなたはラジオニュース番組「一緒に考えるラジオ」の台本を書くベテラン放送作家です。
@@ -129,6 +133,9 @@ SCRIPT_EPISODE_SYSTEM_PROMPT = """\
   "background_prompt": "English prompt for dark background image, no text/letters/words"
 }"""
 
+register_default(PROMPT_KEY_ITEM, SCRIPT_ITEM_SYSTEM_PROMPT)
+register_default(PROMPT_KEY_EPISODE, SCRIPT_EPISODE_SYSTEM_PROMPT)
+
 
 class ScriptwriterStep(BaseStep):
     """Generate radio scripts from analyzed news articles."""
@@ -144,6 +151,8 @@ class ScriptwriterStep(BaseStep):
         Phase 2: Episode composition (1 AI call)
         """
         provider, model = get_step_provider(self.step_name.value)
+        item_prompt, item_prompt_version = await get_active_prompt(session, PROMPT_KEY_ITEM)
+        episode_prompt, episode_prompt_version = await get_active_prompt(session, PROMPT_KEY_EPISODE)
         item_scripts: list[dict] = []
         total_input_tokens = 0
         total_output_tokens = 0
@@ -152,13 +161,15 @@ class ScriptwriterStep(BaseStep):
 
         # Phase 1: per-article scripts
         for item in items:
-            result = await self._script_item(item, provider, model, session, episode_id)
+            result = await self._script_item(item, provider, model, item_prompt, session, episode_id)
             item_scripts.append(result)
             total_input_tokens += result["input_tokens"]
             total_output_tokens += result["output_tokens"]
 
         # Phase 2: episode composition
-        episode_script = await self._compose_episode(item_scripts, provider, model, session, episode_id)
+        episode_script = await self._compose_episode(
+            item_scripts, provider, model, episode_prompt, session, episode_id
+        )
         total_input_tokens += episode_script["input_tokens"]
         total_output_tokens += episode_script["output_tokens"]
 
@@ -177,6 +188,12 @@ class ScriptwriterStep(BaseStep):
             result["thumbnail_prompt"] = episode_script["thumbnail_prompt"]
         if episode_script.get("background_prompt"):
             result["background_prompt"] = episode_script["background_prompt"]
+        if item_prompt_version is not None:
+            result["prompt_versions"] = result.get("prompt_versions", {})
+            result["prompt_versions"]["script_item"] = item_prompt_version
+        if episode_prompt_version is not None:
+            result["prompt_versions"] = result.get("prompt_versions", {})
+            result["prompt_versions"]["script_episode"] = episode_prompt_version
         return result
 
     async def _script_item(
@@ -184,6 +201,7 @@ class ScriptwriterStep(BaseStep):
         item: NewsItem,
         provider,
         model: str,
+        system_prompt: str,
         session: AsyncSession,
         episode_id: int,
     ) -> dict:
@@ -222,7 +240,7 @@ class ScriptwriterStep(BaseStep):
         response = await provider.generate(
             prompt=prompt,
             model=model,
-            system=SCRIPT_ITEM_SYSTEM_PROMPT,
+            system=system_prompt,
         )
 
         data = parse_json_response(response.content)
@@ -249,6 +267,7 @@ class ScriptwriterStep(BaseStep):
         item_scripts: list[dict],
         provider,
         model: str,
+        system_prompt: str,
         session: AsyncSession,
         episode_id: int,
     ) -> dict:
@@ -271,7 +290,7 @@ class ScriptwriterStep(BaseStep):
         response = await provider.generate(
             prompt=prompt,
             model=model,
-            system=SCRIPT_EPISODE_SYSTEM_PROMPT,
+            system=system_prompt,
         )
 
         data = parse_json_response(response.content)

--- a/backend/app/pipeline/video.py
+++ b/backend/app/pipeline/video.py
@@ -13,12 +13,48 @@ from app.models import Episode, NewsItem, PipelineStep, StepName
 from app.pipeline.base import BaseStep
 from app.pipeline.utils import parse_json_response
 from app.services.ai_provider import get_step_provider
+from app.services.prompt_loader import get_active_prompt, register_default
 from app.services.visual_provider import get_visual_provider
 
 logger = logging.getLogger(__name__)
 
 # Font path for Japanese text rendering (Noto Sans CJK)
 FONT_PATH = "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"
+
+PROMPT_KEY = "youtube_metadata"
+
+YOUTUBE_METADATA_SYSTEM_PROMPT = """\
+あなたはYouTubeのSEO・アルゴリズム最適化の専門家です。
+ニュースラジオ番組の動画に最適なメタデータを生成してください。
+
+## ルール
+
+### title（60文字以内）
+- 検索されやすいキーワードを自然に含める
+- クリックベイトにならない範囲で興味を引く
+- 【】で主要トピックを冒頭に
+
+### description（日本語、2000文字以内）
+- 冒頭3行で要点（折りたたみ前に表示される部分が重要）
+- ⏱ タイムスタンプ（0:00 オープニング、おおよそのセクション位置）
+- 📌 ニュース一覧
+- 関連キーワードを自然に含める
+- 末尾にクレジット: 🎙 音声: VOICEVOX / 📻 AI News Radio Japan
+
+### tags（配列、合計500文字以内）
+- ニュース関連キーワード
+- 地域名・トピック固有のタグ
+- 日本語と英語を混ぜる
+- 15-25個程度
+
+以下のJSON形式で回答してください。JSON以外のテキストは含めないでください:
+{
+  "title": "動画タイトル",
+  "description": "概要文",
+  "tags": ["タグ1", "タグ2", ...]
+}"""
+
+register_default(PROMPT_KEY, YOUTUBE_METADATA_SYSTEM_PROMPT)
 
 
 class VideoStep(BaseStep):
@@ -145,6 +181,7 @@ class VideoStep(BaseStep):
         """Generate YouTube metadata (title, description, tags) using AI."""
         try:
             provider, model = get_step_provider("script")  # Reuse script step's AI config
+            system_prompt, _prompt_version = await get_active_prompt(session, PROMPT_KEY)
 
             news_summary = "\n".join(f"- {item.title}" for item in news_items)
             duration_min = int(duration_seconds // 60)
@@ -157,38 +194,7 @@ class VideoStep(BaseStep):
                 f"台本の冒頭300文字:\n{script_text[:300]}"
             )
 
-            system = """\
-あなたはYouTubeのSEO・アルゴリズム最適化の専門家です。
-ニュースラジオ番組の動画に最適なメタデータを生成してください。
-
-## ルール
-
-### title（60文字以内）
-- 検索されやすいキーワードを自然に含める
-- クリックベイトにならない範囲で興味を引く
-- 【】で主要トピックを冒頭に
-
-### description（日本語、2000文字以内）
-- 冒頭3行で要点（折りたたみ前に表示される部分が重要）
-- ⏱ タイムスタンプ（0:00 オープニング、おおよそのセクション位置）
-- 📌 ニュース一覧
-- 関連キーワードを自然に含める
-- 末尾にクレジット: 🎙 音声: VOICEVOX / 📻 AI News Radio Japan
-
-### tags（配列、合計500文字以内）
-- ニュース関連キーワード
-- 地域名・トピック固有のタグ
-- 日本語と英語を混ぜる
-- 15-25個程度
-
-以下のJSON形式で回答してください。JSON以外のテキストは含めないでください:
-{
-  "title": "動画タイトル",
-  "description": "概要文",
-  "tags": ["タグ1", "タグ2", ...]
-}"""
-
-            response = await provider.generate(prompt=prompt, model=model, system=system)
+            response = await provider.generate(prompt=prompt, model=model, system=system_prompt)
             data = parse_json_response(response.content)
 
             await self.record_usage(

--- a/backend/app/services/prompt_loader.py
+++ b/backend/app/services/prompt_loader.py
@@ -1,0 +1,54 @@
+"""Load prompt templates from DB with fallback to code defaults."""
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.prompt_template import PromptTemplate
+
+logger = logging.getLogger(__name__)
+
+# Registry of default prompts (populated by pipeline steps at import time)
+_defaults: dict[str, str] = {}
+
+
+def register_default(key: str, content: str) -> None:
+    """Register a default prompt for a given key."""
+    _defaults[key] = content
+
+
+def get_default(key: str) -> str:
+    """Get the default prompt for a given key."""
+    return _defaults.get(key, "")
+
+
+def get_all_defaults() -> dict[str, str]:
+    """Get all registered default prompts."""
+    return dict(_defaults)
+
+
+async def get_active_prompt(session: AsyncSession, key: str) -> tuple[str, int | None]:
+    """Get the active prompt for a key.
+
+    Returns:
+        Tuple of (prompt_content, version_or_None).
+        version is None when using the code default.
+    """
+    result = await session.execute(
+        select(PromptTemplate).where(
+            PromptTemplate.key == key,
+            PromptTemplate.is_active == True,  # noqa: E712
+        ).order_by(PromptTemplate.version.desc()).limit(1)
+    )
+    template = result.scalar_one_or_none()
+
+    if template:
+        return template.content, template.version
+
+    default = _defaults.get(key)
+    if default:
+        return default, None
+
+    logger.warning("No prompt found for key=%s", key)
+    return "", None

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,6 +8,9 @@ import type {
   EpisodeCostResponse,
   ArticleInput,
   ModelPricing,
+  PromptSummary,
+  PromptHistory,
+  PromptTemplateVersion,
 } from "../types";
 
 const client = axios.create({
@@ -53,6 +56,14 @@ export const api = {
   updatePricing: (id: number, data: { model_prefix: string; provider: string; input_price_per_1m: number; output_price_per_1m: number }) =>
     client.put<ModelPricing>(`/pricing/${id}`, data),
   deletePricing: (id: number) => client.delete(`/pricing/${id}`),
+  // Prompt templates
+  getPrompts: () => client.get<PromptSummary[]>("/prompts"),
+  getPrompt: (key: string) => client.get<PromptHistory>(`/prompts/${key}`),
+  updatePrompt: (key: string, content: string) =>
+    client.put<PromptTemplateVersion>(`/prompts/${key}`, { content }),
+  rollbackPrompt: (key: string, version: number) =>
+    client.post<PromptTemplateVersion>(`/prompts/${key}/rollback/${version}`),
+  resetPrompt: (key: string) => client.delete(`/prompts/${key}`),
 };
 
 export default client;

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1,9 +1,47 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { api } from "../api/client";
-import type { ModelPricing } from "../types";
+import type { ModelPricing, PromptSummary, PromptHistory } from "../types";
 
 export default function Settings() {
+  const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState<"pricing" | "prompts">("pricing");
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold text-gray-800 mb-6">{t("settings.title")}</h2>
+
+      {/* Tabs */}
+      <div className="flex gap-1 mb-6 border-b border-gray-200">
+        <button
+          onClick={() => setActiveTab("pricing")}
+          className={`px-4 py-2 text-sm font-medium border-b-2 cursor-pointer ${
+            activeTab === "pricing"
+              ? "border-blue-600 text-blue-600"
+              : "border-transparent text-gray-500 hover:text-gray-700"
+          }`}
+        >
+          {t("settings.pricing.title")}
+        </button>
+        <button
+          onClick={() => setActiveTab("prompts")}
+          className={`px-4 py-2 text-sm font-medium border-b-2 cursor-pointer ${
+            activeTab === "prompts"
+              ? "border-blue-600 text-blue-600"
+              : "border-transparent text-gray-500 hover:text-gray-700"
+          }`}
+        >
+          {t("settings.prompts.title")}
+        </button>
+      </div>
+
+      {activeTab === "pricing" && <PricingSection />}
+      {activeTab === "prompts" && <PromptsSection />}
+    </div>
+  );
+}
+
+function PricingSection() {
   const { t } = useTranslation();
   const [pricing, setPricing] = useState<ModelPricing[]>([]);
   const [loading, setLoading] = useState(true);
@@ -57,158 +95,367 @@ export default function Settings() {
     );
   };
 
-  // Group by provider
   const providers = [...new Set(pricing.map((p) => p.provider))].sort();
 
   return (
-    <div>
-      <h2 className="text-xl font-semibold text-gray-800 mb-6">{t("settings.title")}</h2>
+    <div className="mb-8">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-base font-semibold text-gray-700">{t("settings.pricing.title")}</h3>
+        <button
+          onClick={() => setShowAdd(!showAdd)}
+          className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md font-medium hover:bg-blue-700 cursor-pointer"
+        >
+          {t("settings.pricing.add")}
+        </button>
+      </div>
 
-      {/* Model Pricing Table */}
-      <div className="mb-8">
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="text-base font-semibold text-gray-700">{t("settings.pricing.title")}</h3>
+      {showAdd && (
+        <div className="bg-gray-50 rounded-lg p-4 mb-4 flex gap-2 items-end flex-wrap">
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">{t("settings.pricing.modelPrefix")}</label>
+            <input
+              type="text"
+              value={form.model_prefix}
+              onChange={(e) => setForm({ ...form, model_prefix: e.target.value })}
+              className="px-2 py-1.5 border border-gray-300 rounded text-sm w-40"
+              placeholder="gpt-5"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">{t("settings.pricing.provider")}</label>
+            <input
+              type="text"
+              value={form.provider}
+              onChange={(e) => setForm({ ...form, provider: e.target.value })}
+              className="px-2 py-1.5 border border-gray-300 rounded text-sm w-28"
+              placeholder="openai"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">{t("settings.pricing.inputPrice")}</label>
+            <input
+              type="number"
+              step="0.01"
+              value={form.input_price_per_1m}
+              onChange={(e) => setForm({ ...form, input_price_per_1m: parseFloat(e.target.value) || 0 })}
+              className="px-2 py-1.5 border border-gray-300 rounded text-sm w-24"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">{t("settings.pricing.outputPrice")}</label>
+            <input
+              type="number"
+              step="0.01"
+              value={form.output_price_per_1m}
+              onChange={(e) => setForm({ ...form, output_price_per_1m: parseFloat(e.target.value) || 0 })}
+              className="px-2 py-1.5 border border-gray-300 rounded text-sm w-24"
+            />
+          </div>
           <button
-            onClick={() => setShowAdd(!showAdd)}
-            className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md font-medium hover:bg-blue-700 cursor-pointer"
+            onClick={handleAdd}
+            disabled={!form.model_prefix || !form.provider}
+            className="px-3 py-1.5 bg-green-600 text-white rounded text-sm font-medium hover:bg-green-700 disabled:opacity-50 cursor-pointer"
           >
-            {t("settings.pricing.add")}
+            {t("settings.pricing.save")}
           </button>
         </div>
+      )}
 
-        {showAdd && (
-          <div className="bg-gray-50 rounded-lg p-4 mb-4 flex gap-2 items-end flex-wrap">
-            <div>
-              <label className="block text-xs text-gray-500 mb-1">{t("settings.pricing.modelPrefix")}</label>
-              <input
-                type="text"
-                value={form.model_prefix}
-                onChange={(e) => setForm({ ...form, model_prefix: e.target.value })}
-                className="px-2 py-1.5 border border-gray-300 rounded text-sm w-40"
-                placeholder="gpt-5"
-              />
+      {loading ? (
+        <p className="text-gray-500 text-sm">{t("settings.loading")}</p>
+      ) : (
+        providers.map((provider) => (
+          <div key={provider} className="mb-4">
+            <h4 className="text-sm font-medium text-gray-500 mb-2 uppercase">{provider}</h4>
+            <div className="bg-white rounded-lg shadow overflow-hidden">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 border-b border-gray-200">
+                  <tr>
+                    <th className="text-left px-4 py-2 font-medium text-gray-600">{t("settings.pricing.modelPrefix")}</th>
+                    <th className="text-right px-4 py-2 font-medium text-gray-600">{t("settings.pricing.inputPrice")}</th>
+                    <th className="text-right px-4 py-2 font-medium text-gray-600">{t("settings.pricing.outputPrice")}</th>
+                    <th className="text-right px-4 py-2 font-medium text-gray-600 w-28"></th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {pricing
+                    .filter((p) => p.provider === provider)
+                    .map((p) => (
+                      <tr key={p.id}>
+                        <td className="px-4 py-2 font-mono text-gray-900">{p.model_prefix}</td>
+                        <td className="px-4 py-2 text-right">
+                          {editingId === p.id ? (
+                            <input
+                              type="number"
+                              step="0.01"
+                              value={p.input_price_per_1m}
+                              onChange={(e) => updateRow(p.id, "input_price_per_1m", parseFloat(e.target.value) || 0)}
+                              className="w-24 px-1 py-0.5 border rounded text-right text-sm"
+                            />
+                          ) : (
+                            <span className="text-gray-600">${p.input_price_per_1m}</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2 text-right">
+                          {editingId === p.id ? (
+                            <input
+                              type="number"
+                              step="0.01"
+                              value={p.output_price_per_1m}
+                              onChange={(e) => updateRow(p.id, "output_price_per_1m", parseFloat(e.target.value) || 0)}
+                              className="w-24 px-1 py-0.5 border rounded text-right text-sm"
+                            />
+                          ) : (
+                            <span className="text-gray-600">${p.output_price_per_1m}</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2 text-right">
+                          {editingId === p.id ? (
+                            <button
+                              onClick={() => handleUpdate(p.id)}
+                              className="text-green-600 hover:text-green-800 text-xs font-medium cursor-pointer"
+                            >
+                              {t("settings.pricing.save")}
+                            </button>
+                          ) : (
+                            <span className="flex gap-2 justify-end">
+                              <button
+                                onClick={() => setEditingId(p.id)}
+                                className="text-blue-600 hover:text-blue-800 text-xs font-medium cursor-pointer"
+                              >
+                                {t("settings.pricing.edit")}
+                              </button>
+                              <button
+                                onClick={() => handleDelete(p.id)}
+                                className="text-red-500 hover:text-red-700 text-xs font-medium cursor-pointer"
+                              >
+                                {t("settings.pricing.delete")}
+                              </button>
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
             </div>
-            <div>
-              <label className="block text-xs text-gray-500 mb-1">{t("settings.pricing.provider")}</label>
-              <input
-                type="text"
-                value={form.provider}
-                onChange={(e) => setForm({ ...form, provider: e.target.value })}
-                className="px-2 py-1.5 border border-gray-300 rounded text-sm w-28"
-                placeholder="openai"
-              />
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function PromptsSection() {
+  const { t } = useTranslation();
+  const [prompts, setPrompts] = useState<PromptSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [detail, setDetail] = useState<PromptHistory | null>(null);
+  const [editContent, setEditContent] = useState("");
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const fetchPrompts = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await api.getPrompts();
+      setPrompts(res.data);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPrompts();
+  }, [fetchPrompts]);
+
+  const openDetail = async (key: string) => {
+    setSelectedKey(key);
+    setEditing(false);
+    const res = await api.getPrompt(key);
+    setDetail(res.data);
+    // Set edit content to active version or default
+    const activeVersion = res.data.versions.find((v) => v.is_active);
+    setEditContent(activeVersion ? activeVersion.content : res.data.default_content);
+  };
+
+  const handleSave = async () => {
+    if (!selectedKey || !editContent.trim()) return;
+    setSaving(true);
+    try {
+      await api.updatePrompt(selectedKey, editContent);
+      await openDetail(selectedKey);
+      setEditing(false);
+      fetchPrompts();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRollback = async (version: number) => {
+    if (!selectedKey) return;
+    await api.rollbackPrompt(selectedKey, version);
+    await openDetail(selectedKey);
+    fetchPrompts();
+  };
+
+  const handleReset = async () => {
+    if (!selectedKey) return;
+    await api.resetPrompt(selectedKey);
+    setDetail(null);
+    setSelectedKey(null);
+    setEditing(false);
+    fetchPrompts();
+  };
+
+  if (loading) {
+    return <p className="text-gray-500 text-sm">{t("settings.loading")}</p>;
+  }
+
+  // Detail view
+  if (selectedKey && detail) {
+    const activeVersion = detail.versions.find((v) => v.is_active);
+    const currentContent = activeVersion ? activeVersion.content : detail.default_content;
+
+    return (
+      <div>
+        <button
+          onClick={() => { setSelectedKey(null); setDetail(null); setEditing(false); }}
+          className="text-blue-600 hover:text-blue-800 text-sm mb-4 cursor-pointer"
+        >
+          &larr; {t("settings.prompts.backToList")}
+        </button>
+
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-800">{detail.name}</h3>
+            <p className="text-sm text-gray-500">
+              {activeVersion
+                ? `${t("settings.prompts.version")} ${activeVersion.version} (${t("settings.prompts.custom")})`
+                : t("settings.prompts.usingDefault")}
+            </p>
+          </div>
+          <div className="flex gap-2">
+            {!editing && (
+              <button
+                onClick={() => { setEditContent(currentContent); setEditing(true); }}
+                className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md font-medium hover:bg-blue-700 cursor-pointer"
+              >
+                {t("settings.prompts.edit")}
+              </button>
+            )}
+            {activeVersion && (
+              <button
+                onClick={handleReset}
+                className="px-3 py-1.5 text-sm bg-gray-200 text-gray-700 rounded-md font-medium hover:bg-gray-300 cursor-pointer"
+              >
+                {t("settings.prompts.resetDefault")}
+              </button>
+            )}
+          </div>
+        </div>
+
+        {editing ? (
+          <div>
+            <textarea
+              value={editContent}
+              onChange={(e) => setEditContent(e.target.value)}
+              className="w-full h-96 px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono resize-y focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+            <div className="flex gap-2 mt-3">
+              <button
+                onClick={handleSave}
+                disabled={saving || !editContent.trim()}
+                className="px-4 py-2 bg-green-600 text-white rounded-md text-sm font-medium hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+              >
+                {saving ? t("settings.prompts.saving") : t("settings.prompts.save")}
+              </button>
+              <button
+                onClick={() => setEditing(false)}
+                className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-300 cursor-pointer"
+              >
+                {t("settings.prompts.cancel")}
+              </button>
             </div>
-            <div>
-              <label className="block text-xs text-gray-500 mb-1">{t("settings.pricing.inputPrice")}</label>
-              <input
-                type="number"
-                step="0.01"
-                value={form.input_price_per_1m}
-                onChange={(e) => setForm({ ...form, input_price_per_1m: parseFloat(e.target.value) || 0 })}
-                className="px-2 py-1.5 border border-gray-300 rounded text-sm w-24"
-              />
+          </div>
+        ) : (
+          <pre className="w-full bg-gray-50 border border-gray-200 rounded-lg p-4 text-sm font-mono whitespace-pre-wrap overflow-auto max-h-96">
+            {currentContent}
+          </pre>
+        )}
+
+        {/* Version history */}
+        {detail.versions.length > 0 && (
+          <div className="mt-6">
+            <h4 className="text-sm font-semibold text-gray-700 mb-3">{t("settings.prompts.history")}</h4>
+            <div className="space-y-2">
+              {detail.versions.map((v) => (
+                <div
+                  key={v.id}
+                  className={`flex items-center justify-between px-4 py-2 rounded-lg border ${
+                    v.is_active ? "border-blue-300 bg-blue-50" : "border-gray-200 bg-white"
+                  }`}
+                >
+                  <div className="text-sm">
+                    <span className="font-medium text-gray-800">
+                      v{v.version}
+                    </span>
+                    {v.is_active && (
+                      <span className="ml-2 px-2 py-0.5 bg-blue-100 text-blue-700 rounded text-xs font-medium">
+                        {t("settings.prompts.active")}
+                      </span>
+                    )}
+                    <span className="ml-3 text-gray-500 text-xs">
+                      {new Date(v.created_at).toLocaleString()}
+                    </span>
+                  </div>
+                  {!v.is_active && (
+                    <button
+                      onClick={() => handleRollback(v.version)}
+                      className="text-blue-600 hover:text-blue-800 text-xs font-medium cursor-pointer"
+                    >
+                      {t("settings.prompts.restore")}
+                    </button>
+                  )}
+                </div>
+              ))}
             </div>
-            <div>
-              <label className="block text-xs text-gray-500 mb-1">{t("settings.pricing.outputPrice")}</label>
-              <input
-                type="number"
-                step="0.01"
-                value={form.output_price_per_1m}
-                onChange={(e) => setForm({ ...form, output_price_per_1m: parseFloat(e.target.value) || 0 })}
-                className="px-2 py-1.5 border border-gray-300 rounded text-sm w-24"
-              />
-            </div>
-            <button
-              onClick={handleAdd}
-              disabled={!form.model_prefix || !form.provider}
-              className="px-3 py-1.5 bg-green-600 text-white rounded text-sm font-medium hover:bg-green-700 disabled:opacity-50 cursor-pointer"
-            >
-              {t("settings.pricing.save")}
-            </button>
           </div>
         )}
+      </div>
+    );
+  }
 
-        {loading ? (
-          <p className="text-gray-500 text-sm">{t("settings.loading")}</p>
-        ) : (
-          providers.map((provider) => (
-            <div key={provider} className="mb-4">
-              <h4 className="text-sm font-medium text-gray-500 mb-2 uppercase">{provider}</h4>
-              <div className="bg-white rounded-lg shadow overflow-hidden">
-                <table className="w-full text-sm">
-                  <thead className="bg-gray-50 border-b border-gray-200">
-                    <tr>
-                      <th className="text-left px-4 py-2 font-medium text-gray-600">{t("settings.pricing.modelPrefix")}</th>
-                      <th className="text-right px-4 py-2 font-medium text-gray-600">{t("settings.pricing.inputPrice")}</th>
-                      <th className="text-right px-4 py-2 font-medium text-gray-600">{t("settings.pricing.outputPrice")}</th>
-                      <th className="text-right px-4 py-2 font-medium text-gray-600 w-28"></th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-100">
-                    {pricing
-                      .filter((p) => p.provider === provider)
-                      .map((p) => (
-                        <tr key={p.id}>
-                          <td className="px-4 py-2 font-mono text-gray-900">{p.model_prefix}</td>
-                          <td className="px-4 py-2 text-right">
-                            {editingId === p.id ? (
-                              <input
-                                type="number"
-                                step="0.01"
-                                value={p.input_price_per_1m}
-                                onChange={(e) => updateRow(p.id, "input_price_per_1m", parseFloat(e.target.value) || 0)}
-                                className="w-24 px-1 py-0.5 border rounded text-right text-sm"
-                              />
-                            ) : (
-                              <span className="text-gray-600">${p.input_price_per_1m}</span>
-                            )}
-                          </td>
-                          <td className="px-4 py-2 text-right">
-                            {editingId === p.id ? (
-                              <input
-                                type="number"
-                                step="0.01"
-                                value={p.output_price_per_1m}
-                                onChange={(e) => updateRow(p.id, "output_price_per_1m", parseFloat(e.target.value) || 0)}
-                                className="w-24 px-1 py-0.5 border rounded text-right text-sm"
-                              />
-                            ) : (
-                              <span className="text-gray-600">${p.output_price_per_1m}</span>
-                            )}
-                          </td>
-                          <td className="px-4 py-2 text-right">
-                            {editingId === p.id ? (
-                              <button
-                                onClick={() => handleUpdate(p.id)}
-                                className="text-green-600 hover:text-green-800 text-xs font-medium cursor-pointer"
-                              >
-                                {t("settings.pricing.save")}
-                              </button>
-                            ) : (
-                              <span className="flex gap-2 justify-end">
-                                <button
-                                  onClick={() => setEditingId(p.id)}
-                                  className="text-blue-600 hover:text-blue-800 text-xs font-medium cursor-pointer"
-                                >
-                                  {t("settings.pricing.edit")}
-                                </button>
-                                <button
-                                  onClick={() => handleDelete(p.id)}
-                                  className="text-red-500 hover:text-red-700 text-xs font-medium cursor-pointer"
-                                >
-                                  {t("settings.pricing.delete")}
-                                </button>
-                              </span>
-                            )}
-                          </td>
-                        </tr>
-                      ))}
-                  </tbody>
-                </table>
+  // List view
+  return (
+    <div>
+      <div className="space-y-2">
+        {prompts.map((p) => (
+          <div
+            key={p.key}
+            onClick={() => openDetail(p.key)}
+            className="flex items-center justify-between px-4 py-3 bg-white rounded-lg shadow border border-gray-200 hover:border-blue-300 cursor-pointer transition-colors"
+          >
+            <div>
+              <div className="font-medium text-gray-800">{p.name}</div>
+              <div className="text-xs text-gray-500 mt-1 font-mono truncate max-w-lg">
+                {p.content_preview}
               </div>
             </div>
-          ))
-        )}
+            <div className="text-right shrink-0 ml-4">
+              {p.has_custom ? (
+                <span className="px-2 py-1 bg-blue-100 text-blue-700 rounded text-xs font-medium">
+                  v{p.active_version} ({t("settings.prompts.custom")})
+                </span>
+              ) : (
+                <span className="px-2 py-1 bg-gray-100 text-gray-600 rounded text-xs font-medium">
+                  {t("settings.prompts.default")}
+                </span>
+              )}
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -168,6 +168,22 @@
       "edit": "Edit",
       "save": "Save",
       "delete": "Delete"
+    },
+    "prompts": {
+      "title": "Prompt Templates",
+      "backToList": "Back to list",
+      "version": "Version",
+      "custom": "Custom",
+      "default": "Default",
+      "usingDefault": "Using default prompt",
+      "edit": "Edit",
+      "save": "Save",
+      "saving": "Saving...",
+      "cancel": "Cancel",
+      "resetDefault": "Reset to Default",
+      "history": "Version History",
+      "active": "Active",
+      "restore": "Restore"
     }
   },
   "errors": {

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -168,6 +168,22 @@
       "edit": "編集",
       "save": "保存",
       "delete": "削除"
+    },
+    "prompts": {
+      "title": "プロンプトテンプレート",
+      "backToList": "一覧に戻る",
+      "version": "バージョン",
+      "custom": "カスタム",
+      "default": "デフォルト",
+      "usingDefault": "デフォルトプロンプトを使用中",
+      "edit": "編集",
+      "save": "保存",
+      "saving": "保存中...",
+      "cancel": "キャンセル",
+      "resetDefault": "デフォルトに戻す",
+      "history": "バージョン履歴",
+      "active": "使用中",
+      "restore": "復元"
     }
   },
   "errors": {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -119,3 +119,30 @@ export interface ModelPricing {
   created_at: string;
   updated_at: string;
 }
+
+export interface PromptSummary {
+  key: string;
+  name: string;
+  active_version: number | null;
+  has_custom: boolean;
+  content_preview: string;
+}
+
+export interface PromptTemplateVersion {
+  id: number;
+  key: string;
+  name: string;
+  content: string;
+  version: number;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PromptHistory {
+  key: string;
+  name: string;
+  default_content: string;
+  active_version: number | null;
+  versions: PromptTemplateVersion[];
+}


### PR DESCRIPTION
## Summary
- プロンプトテンプレートをDBで管理し、WebUIから編集・バージョン管理できるようにする
- 全パイプラインステップ（factcheck, analysis, script_item, script_episode, youtube_metadata）のプロンプトが対象
- DB にカスタムプロンプトがなければコード内デフォルトにフォールバック
- プロンプト更新は新バージョンとして保存（上書きしない）、過去バージョンへのロールバック可能
- エピソードの output_data に使用したプロンプトバージョンを記録（再現性）

## Changes
### Backend
- `PromptTemplate` モデル + Alembic migration (009)
- `prompt_loader` サービス: デフォルト登録、DB読み込み + フォールバック
- `/api/prompts` CRUD API: 一覧・詳細・更新・ロールバック・リセット
- 全パイプラインステップを DB プロンプト読み込みに対応

### Frontend
- Settings ページに「プロンプトテンプレート」タブを追加
- プロンプト一覧 → 詳細編集 → バージョン履歴・復元 UI
- i18n 対応 (ja/en)

## Test plan
- [ ] `alembic upgrade head` でマイグレーションが通ること
- [ ] `GET /api/prompts` で5つのプロンプト一覧が返ること
- [ ] `PUT /api/prompts/factcheck` でカスタムプロンプトを保存し、パイプライン実行時にそれが使われること
- [ ] バージョンロールバック・デフォルトリセットが動作すること
- [ ] Settings 画面のプロンプトタブでの編集・保存・復元が動作すること
- [ ] カスタムプロンプト未設定時にコードデフォルトにフォールバックすること

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)