### PR TITLE
feat: 記事単位での承認/除外機能 (#74)

### DIFF
--- a/backend/alembic/versions/012_add_news_item_excluded.py
+++ b/backend/alembic/versions/012_add_news_item_excluded.py
@@ -1,0 +1,24 @@
+"""Add excluded and excluded_at_step to news_items
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-03-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "012"
+down_revision = "011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("news_items", sa.Column("excluded", sa.Boolean(), nullable=False, server_default=sa.false()))
+    op.add_column("news_items", sa.Column("excluded_at_step", sa.String(50), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("news_items", "excluded_at_step")
+    op.drop_column("news_items", "excluded")

--- a/backend/app/api/pipeline.py
+++ b/backend/app/api/pipeline.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.schemas import (
+    ApproveRequest,
     EpisodeScriptEditRequest,
     RejectRequest,
     RunStepRequest,
@@ -97,11 +98,13 @@ async def run_step(
 @router.post("/steps/{step_id}/approve", response_model=StepResponse)
 async def approve_step(
     step_id: int,
+    body: ApproveRequest | None = None,
     session: AsyncSession = Depends(get_session),
 ) -> PipelineStep:
-    """Approve a pipeline step."""
+    """Approve a pipeline step, optionally excluding specific news items."""
     try:
-        return await engine.approve_step(step_id, session)
+        excluded_ids = body.excluded_item_ids if body else None
+        return await engine.approve_step(step_id, session, excluded_item_ids=excluded_ids)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -35,6 +35,12 @@ class RunStepRequest(BaseModel):
     queries: list[str] | None = None  # Override collection queries
 
 
+class ApproveRequest(BaseModel):
+    """Request body for approving a step with optional per-article exclusion."""
+
+    excluded_item_ids: list[int] = []
+
+
 class RejectRequest(BaseModel):
     """Request body for rejecting a step."""
 
@@ -127,6 +133,8 @@ class NewsItemResponse(BaseModel):
     script_text: str | None = None
     group_id: int | None = None
     is_group_primary: bool | None = None
+    excluded: bool = False
+    excluded_at_step: str | None = None
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/backend/app/models/news_item.py
+++ b/backend/app/models/news_item.py
@@ -31,6 +31,10 @@ class NewsItem(Base):
     group_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
     is_group_primary: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
+    # Approval (per-article exclusion)
+    excluded: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+    excluded_at_step: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
     # Script
     script_text: Mapped[str | None] = mapped_column(Text, nullable=True)
 

--- a/backend/app/pipeline/base.py
+++ b/backend/app/pipeline/base.py
@@ -84,11 +84,18 @@ class BaseStep(ABC):
             await session.commit()
             raise
 
-    async def _get_news_items(self, episode_id: int, session: AsyncSession) -> list[NewsItem]:
-        """Load all NewsItems for the episode."""
-        result = await session.execute(
-            select(NewsItem).where(NewsItem.episode_id == episode_id).order_by(NewsItem.id)
-        )
+    async def _get_news_items(
+        self, episode_id: int, session: AsyncSession, *, include_excluded: bool = False
+    ) -> list[NewsItem]:
+        """Load NewsItems for the episode.
+
+        By default, excluded items are filtered out. Pass include_excluded=True
+        to load all items (e.g. for collection step).
+        """
+        query = select(NewsItem).where(NewsItem.episode_id == episode_id)
+        if not include_excluded:
+            query = query.where(NewsItem.excluded.is_(False))
+        result = await session.execute(query.order_by(NewsItem.id))
         return list(result.scalars().all())
 
     async def _get_input_data(self, episode_id: int, session: AsyncSession) -> dict:

--- a/backend/app/pipeline/engine.py
+++ b/backend/app/pipeline/engine.py
@@ -137,13 +137,33 @@ class PipelineEngine:
         step_instance = step_class()
         await step_instance.run(episode_id, session, **kwargs)
 
-    async def approve_step(self, step_id: int, session: AsyncSession) -> PipelineStep:
-        """Approve a pipeline step that is awaiting approval."""
+    async def approve_step(
+        self, step_id: int, session: AsyncSession, excluded_item_ids: list[int] | None = None
+    ) -> PipelineStep:
+        """Approve a pipeline step that is awaiting approval.
+
+        Args:
+            step_id: The pipeline step ID.
+            session: Database session.
+            excluded_item_ids: Optional list of news item IDs to exclude at this step.
+        """
         result = await session.execute(select(PipelineStep).where(PipelineStep.id == step_id))
         step = result.scalar_one()
 
         if step.status != StepStatus.NEEDS_APPROVAL:
             raise ValueError(f"Step is not awaiting approval (current status: {step.status.value})")
+
+        # Mark excluded items
+        if excluded_item_ids:
+            items_result = await session.execute(
+                select(NewsItem).where(
+                    NewsItem.episode_id == step.episode_id,
+                    NewsItem.id.in_(excluded_item_ids),
+                )
+            )
+            for item in items_result.scalars():
+                item.excluded = True
+                item.excluded_at_step = step.step_name.value
 
         step.status = StepStatus.APPROVED
         step.approved_at = datetime.now(UTC)

--- a/backend/mcp_server/client.py
+++ b/backend/mcp_server/client.py
@@ -85,9 +85,12 @@ class AINewsRadioClient:
             body["queries"] = queries
         return await self._request("POST", f"/api/episodes/{episode_id}/steps/{step_name}/run", json=body)
 
-    async def approve_step(self, step_id: int) -> dict:
+    async def approve_step(self, step_id: int, excluded_item_ids: list[int] | None = None) -> dict:
         """POST /api/steps/{step_id}/approve"""
-        return await self._request("POST", f"/api/steps/{step_id}/approve")
+        body = {}
+        if excluded_item_ids:
+            body["excluded_item_ids"] = excluded_item_ids
+        return await self._request("POST", f"/api/steps/{step_id}/approve", json=body if body else None)
 
     async def reject_step(self, step_id: int, reason: str) -> dict:
         """POST /api/steps/{step_id}/reject"""

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -141,14 +141,22 @@ async def _get_episode_status(args: dict) -> str:
         lines.append(line)
 
     if news_items:
-        lines.extend(["", f"News Items ({len(news_items)}):"])
-        for item in news_items:
+        active = [i for i in news_items if not i.get("excluded")]
+        excluded = [i for i in news_items if i.get("excluded")]
+        lines.extend(["", f"News Items ({len(active)}):"])
+        for item in active:
             fc = ""
             if item.get("fact_check_score") is not None:
                 fc = f" [fact-check: {item['fact_check_score']}/5]"
             script = " [script: ready]" if item.get("script_text") else ""
             lines.append(f"  - {item['title']}{fc}{script}")
             lines.append(f"    {item['source_name']}: {item['source_url']}")
+        if excluded:
+            lines.extend(["", f"Excluded Items ({len(excluded)}):"])
+            for item in excluded:
+                step = item.get("excluded_at_step", "?")
+                lines.append(f"  x {item['title']} (excluded at: {step})")
+                lines.append(f"    {item['source_name']}: {item['source_url']}")
 
     return "\n".join(lines)
 
@@ -173,12 +181,15 @@ async def _run_step(args: dict) -> str:
 async def _approve_step(args: dict) -> str:
     episode_id = args["episode_id"]
     step_name = args["step_name"]
+    excluded_item_ids = args.get("excluded_item_ids")
 
     step_id = await client.resolve_step_id(episode_id, step_name)
-    step = await client.approve_step(step_id)
+    step = await client.approve_step(step_id, excluded_item_ids)
 
     next_step = _next_step(step_name)
     lines = [f"Step '{step_name}' approved for episode #{episode_id}."]
+    if excluded_item_ids:
+        lines.append(f"Excluded {len(excluded_item_ids)} item(s): {excluded_item_ids}")
     if next_step:
         lines.append(f"Next step: run_step with step_name='{next_step}'")
     else:

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -114,7 +114,11 @@ def get_tool_definitions() -> list[Tool]:
         ),
         Tool(
             name="approve_step",
-            description="Approve a completed pipeline step (status must be needs_approval). Allows the next step to proceed.",
+            description=(
+                "Approve a completed pipeline step (status must be needs_approval). "
+                "Optionally exclude specific news items by passing their IDs. "
+                "Excluded items will be skipped in subsequent steps."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -123,6 +127,11 @@ def get_tool_definitions() -> list[Tool]:
                         "type": "string",
                         "enum": STEP_NAMES,
                         "description": "Pipeline step to approve",
+                    },
+                    "excluded_item_ids": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "description": "News item IDs to exclude from this step onwards (optional)",
                     },
                 },
                 "required": ["episode_id", "step_name"],

--- a/backend/tests/test_mcp_tools.py
+++ b/backend/tests/test_mcp_tools.py
@@ -144,7 +144,15 @@ class TestClient:
         with patch.object(api_client, "_request", new_callable=AsyncMock) as mock:
             mock.return_value = {"id": 5, "step_name": "collection", "status": "approved"}
             await api_client.approve_step(5)
-            mock.assert_called_once_with("POST", "/api/steps/5/approve")
+            mock.assert_called_once_with("POST", "/api/steps/5/approve", json=None)
+
+    async def test_approve_step_with_exclusions(self, api_client):
+        with patch.object(api_client, "_request", new_callable=AsyncMock) as mock:
+            mock.return_value = {"id": 5, "step_name": "collection", "status": "approved"}
+            await api_client.approve_step(5, [1, 3])
+            mock.assert_called_once_with(
+                "POST", "/api/steps/5/approve", json={"excluded_item_ids": [1, 3]}
+            )
 
     async def test_reject_step(self, api_client):
         with patch.object(api_client, "_request", new_callable=AsyncMock) as mock:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -33,8 +33,8 @@ export const api = {
     client.delete(`/episodes/${episodeId}`),
   runStep: (episodeId: number, stepName: string, body?: { queries?: string[] }) =>
     client.post<PipelineStep>(`/episodes/${episodeId}/steps/${stepName}/run`, body),
-  approveStep: (stepId: number) =>
-    client.post<PipelineStep>(`/steps/${stepId}/approve`),
+  approveStep: (stepId: number, excludedItemIds?: number[]) =>
+    client.post<PipelineStep>(`/steps/${stepId}/approve`, excludedItemIds?.length ? { excluded_item_ids: excludedItemIds } : undefined),
   rejectStep: (stepId: number, reason: string) =>
     client.post<PipelineStep>(`/steps/${stepId}/reject`, { reason }),
   editItemScript: (episodeId: number, newsItemId: number, scriptText: string) =>

--- a/frontend/src/components/ApprovalGate.tsx
+++ b/frontend/src/components/ApprovalGate.tsx
@@ -4,6 +4,8 @@ import { api } from "../api/client";
 import type { PipelineStep, NewsItem } from "../types";
 import StepDataRenderer from "./step-renderers/StepDataRenderer";
 
+const ITEM_APPROVAL_STEPS = ["collection", "factcheck", "analysis"];
+
 interface Props {
   step: PipelineStep;
   newsItems: NewsItem[];
@@ -16,14 +18,42 @@ export default function ApprovalGate({ step, newsItems, onUpdated }: Props) {
   const [reason, setReason] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const activeItems = newsItems.filter((item) => !item.excluded);
+  const [excludedIds, setExcludedIds] = useState<Set<number>>(new Set());
 
   if (step.status !== "needs_approval") return null;
 
+  const showItemSelection = ITEM_APPROVAL_STEPS.includes(step.step_name) && activeItems.length > 0;
+
+  const toggleItem = (id: number) => {
+    setExcludedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (excludedIds.size === 0) {
+      setExcludedIds(new Set(activeItems.map((item) => item.id)));
+    } else {
+      setExcludedIds(new Set());
+    }
+  };
+
+  const approvedCount = activeItems.length - excludedIds.size;
+
   const handleApprove = async () => {
+    if (showItemSelection && approvedCount === 0) return;
     try {
       setSubmitting(true);
       setError(null);
-      await api.approveStep(step.id);
+      const ids = excludedIds.size > 0 ? Array.from(excludedIds) : undefined;
+      await api.approveStep(step.id, ids);
       onUpdated();
     } catch (e) {
       setError(e instanceof Error ? e.message : t("approval.approveFailed"));
@@ -46,6 +76,22 @@ export default function ApprovalGate({ step, newsItems, onUpdated }: Props) {
     } finally {
       setSubmitting(false);
     }
+  };
+
+  const getScoreBadge = (item: NewsItem) => {
+    if (item.fact_check_score == null) return null;
+    const score = item.fact_check_score;
+    const color =
+      score >= 4
+        ? "bg-green-100 text-green-800"
+        : score >= 3
+          ? "bg-yellow-100 text-yellow-800"
+          : "bg-red-100 text-red-800";
+    return (
+      <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${color}`}>
+        {score}/5
+      </span>
+    );
   };
 
   return (
@@ -74,14 +120,66 @@ export default function ApprovalGate({ step, newsItems, onUpdated }: Props) {
         </div>
       )}
 
+      {showItemSelection && (
+        <div className="mb-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-medium text-gray-700">
+              {t("approval.selectArticles")}
+            </span>
+            <button
+              onClick={toggleAll}
+              className="text-xs text-blue-600 hover:text-blue-800 cursor-pointer"
+            >
+              {excludedIds.size === 0 ? t("approval.deselectAll") : t("approval.selectAll")}
+            </button>
+          </div>
+          <div className="space-y-1">
+            {activeItems.map((item) => {
+              const isExcluded = excludedIds.has(item.id);
+              return (
+                <label
+                  key={item.id}
+                  className={`flex items-center gap-2 p-2 rounded border cursor-pointer transition-colors ${
+                    isExcluded
+                      ? "bg-gray-100 border-gray-200 opacity-60"
+                      : "bg-white border-gray-300 hover:border-blue-400"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={!isExcluded}
+                    onChange={() => toggleItem(item.id)}
+                    className="rounded border-gray-300 text-blue-600 cursor-pointer"
+                  />
+                  <span className={`text-sm flex-1 ${isExcluded ? "line-through text-gray-400" : "text-gray-800"}`}>
+                    {item.title}
+                  </span>
+                  {getScoreBadge(item)}
+                  <span className="text-xs text-gray-400">{item.source_name}</span>
+                </label>
+              );
+            })}
+          </div>
+          {excludedIds.size > 0 && (
+            <p className="text-xs text-orange-600 mt-2">
+              {t("approval.excludeCount", { count: excludedIds.size })}
+            </p>
+          )}
+        </div>
+      )}
+
       {!rejecting ? (
-        <div className="flex gap-2">
+        <div className="flex gap-2 items-center">
           <button
             onClick={handleApprove}
-            disabled={submitting}
+            disabled={submitting || (showItemSelection && approvedCount === 0)}
             className="px-4 py-2 bg-green-600 text-white rounded-md text-sm font-medium hover:bg-green-700 disabled:opacity-50 cursor-pointer"
           >
-            {submitting ? t("approval.processing") : t("approval.approve")}
+            {submitting
+              ? t("approval.processing")
+              : showItemSelection
+                ? t("approval.approveSelected", { count: approvedCount })
+                : t("approval.approve")}
           </button>
           <button
             onClick={() => setRejecting(true)}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -63,7 +63,12 @@
     "rejectPlaceholder": "Enter rejection reason...",
     "processing": "Processing...",
     "approveFailed": "Approval failed",
-    "rejectFailed": "Rejection failed"
+    "rejectFailed": "Rejection failed",
+    "selectArticles": "Select articles to approve",
+    "selectAll": "Select all",
+    "deselectAll": "Deselect all",
+    "approveSelected": "Approve {{count}} selected",
+    "excludeCount": "{{count}} article(s) will be excluded"
   },
   "pipeline": {
     "inputData": "Input Data",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -63,7 +63,12 @@
     "rejectPlaceholder": "却下理由を入力してください...",
     "processing": "処理中...",
     "approveFailed": "承認に失敗しました",
-    "rejectFailed": "却下に失敗しました"
+    "rejectFailed": "却下に失敗しました",
+    "selectArticles": "承認する記事を選択してください",
+    "selectAll": "すべて選択",
+    "deselectAll": "すべて解除",
+    "approveSelected": "選択した{{count}}件を承認",
+    "excludeCount": "{{count}}件の記事を除外します"
   },
   "pipeline": {
     "inputData": "入力データ",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -57,6 +57,8 @@ export interface NewsItem {
   script_text: string | null;
   group_id: number | null;
   is_group_primary: boolean | null;
+  excluded: boolean;
+  excluded_at_step: string | null;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary
- 承認ゲートで記事ごとにチェックボックスで承認/除外を選択可能に
- 除外された記事は以降のパイプラインステップ（分析・台本生成等）でスキップ
- MCP ツール `approve_step` にも `excluded_item_ids` パラメータを追加

## 変更内容
- **DB**: `news_items` に `excluded` (bool), `excluded_at_step` (string) カラム追加
- **Backend**: `approve_step` API で除外記事IDリストを受付、`BaseStep._get_news_items` で除外フィルタ
- **Frontend**: `ApprovalGate` に記事選択UI（チェックボックス、ファクトチェックスコア表示、一括選択/解除）
- **MCP**: `approve_step` ツール、クライアント、ハンドラーを拡張
- **i18n**: 日本語・英語の翻訳追加

## Test plan
- [x] 既存テスト 204件 全パス
- [ ] WebUI で承認ゲート表示時に記事一覧がチェックボックス付きで表示されること
- [ ] 一部記事を除外して承認後、次ステップで除外記事がスキップされること
- [ ] MCP `approve_step` で `excluded_item_ids` を指定して除外できること
- [ ] 除外記事が `get_episode_status` で「Excluded Items」セクションに表示されること

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)