### PR TITLE
feat: Brave Search APIのコスト追跡を追加

### DIFF
--- a/backend/alembic/versions/013_add_brave_search_pricing.py
+++ b/backend/alembic/versions/013_add_brave_search_pricing.py
@@ -1,0 +1,35 @@
+"""Add Brave Search pricing data
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-03-13
+"""
+
+from alembic import op
+
+revision = "013"
+down_revision = "012"
+branch_labels = None
+depends_on = None
+
+# Brave Search API: $5 per 1,000 queries = $5,000 per 1M queries
+# We use input_price_per_1m to store per-1M-query price, output_price is 0.
+BRAVE_PRICING = {
+    "model_prefix": "brave-search",
+    "provider": "brave",
+    "input_price_per_1m": 5000.0,  # $5 per 1K = $5,000 per 1M
+    "output_price_per_1m": 0.0,
+}
+
+
+def upgrade() -> None:
+    op.execute(
+        f"INSERT INTO model_pricing (model_prefix, provider, input_price_per_1m, output_price_per_1m) "
+        f"VALUES ('{BRAVE_PRICING['model_prefix']}', '{BRAVE_PRICING['provider']}', "
+        f"{BRAVE_PRICING['input_price_per_1m']}, {BRAVE_PRICING['output_price_per_1m']}) "
+        f"ON CONFLICT (model_prefix) DO NOTHING"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM model_pricing WHERE model_prefix = 'brave-search'")

--- a/backend/app/pipeline/collector.py
+++ b/backend/app/pipeline/collector.py
@@ -81,7 +81,7 @@ class CollectorStep(BaseStep):
         queries = kwargs.get("queries")
 
         if method == "brave":
-            articles = await self._collect_brave(queries=queries)
+            articles = await self._collect_brave(session, episode_id, queries=queries)
         else:
             raise ValueError(f"Unknown collection method: {method}")
 
@@ -137,9 +137,11 @@ class CollectorStep(BaseStep):
             output["factcheck_included"] = True
         return output
 
-    async def _collect_brave(self, queries: list[str] | None = None) -> list[dict]:
+    async def _collect_brave(
+        self, session: AsyncSession, episode_id: int, queries: list[str] | None = None
+    ) -> list[dict]:
         """Collect news using Brave Search API."""
-        from app.services.brave_search import BraveSearchService
+        from app.services.brave_search import BRAVE_COST_PER_QUERY, BraveSearchService
 
         service = BraveSearchService()
         if not queries:
@@ -162,6 +164,18 @@ class CollectorStep(BaseStep):
                         "source_name": f"Brave Search ({query})",
                     }
                 )
+
+        # Record Brave Search API usage
+        if service.query_count > 0:
+            await self.record_usage(
+                session=session,
+                episode_id=episode_id,
+                provider="brave",
+                model="brave-search",
+                input_tokens=service.query_count,
+                output_tokens=0,
+                cost_usd=service.query_count * BRAVE_COST_PER_QUERY,
+            )
 
         return all_articles
 
@@ -300,7 +314,10 @@ class CollectorStep(BaseStep):
             return False
 
         # --- Pass 2: Additional search ---
+        from app.services.brave_search import BRAVE_COST_PER_QUERY, BraveSearchService
+
         additional_info = ""
+        brave_query_count = 0
         max_rounds = settings.collection_ai_research_max_rounds
         for round_num in range(max_rounds):
             if round_num >= len(search_queries):
@@ -308,10 +325,9 @@ class CollectorStep(BaseStep):
             batch = search_queries[round_num * 3 : (round_num + 1) * 3]
             for query in batch:
                 try:
-                    from app.services.brave_search import BraveSearchService
-
                     search_svc = BraveSearchService()
                     results = await search_svc.web_search(query, count=5)
+                    brave_query_count += 1
                     for r in results:
                         additional_info += f"\n- [{query}] {r.title}: {r.description}\n  URL: {r.url}"
 
@@ -329,6 +345,18 @@ class CollectorStep(BaseStep):
                                 additional_info += f"\n  本文: {crawl_result.body[:2000]}"
                 except Exception as e:
                     logger.warning("Additional search failed for '%s': %s", query, e)
+
+        # Record Brave Search API usage for research queries
+        if brave_query_count > 0:
+            await self.record_usage(
+                session=session,
+                episode_id=episode_id,
+                provider="brave",
+                model="brave-search",
+                input_tokens=brave_query_count,
+                output_tokens=0,
+                cost_usd=brave_query_count * BRAVE_COST_PER_QUERY,
+            )
 
         if not additional_info:
             return False

--- a/backend/app/pipeline/factchecker.py
+++ b/backend/app/pipeline/factchecker.py
@@ -117,7 +117,9 @@ class FactcheckerStep(BaseStep):
             result_data["prompt_version"] = prompt_version
         return result_data
 
-    async def _search_references(self, item: NewsItem) -> str:
+    async def _search_references(
+        self, item: NewsItem, session: AsyncSession, episode_id: int
+    ) -> str:
         """Search for reference material using Brave Search (if available)."""
         try:
             from app.config import settings
@@ -125,10 +127,22 @@ class FactcheckerStep(BaseStep):
             if not settings.brave_search_api_key:
                 return ""
 
-            from app.services.brave_search import BraveSearchService
+            from app.services.brave_search import BRAVE_COST_PER_QUERY, BraveSearchService
 
             service = BraveSearchService()
             results = await service.web_search(item.title, count=5)
+
+            # Record Brave Search API usage
+            await self.record_usage(
+                session=session,
+                episode_id=episode_id,
+                provider="brave",
+                model="brave-search",
+                input_tokens=1,
+                output_tokens=0,
+                cost_usd=BRAVE_COST_PER_QUERY,
+            )
+
             if not results:
                 return ""
 
@@ -153,7 +167,7 @@ class FactcheckerStep(BaseStep):
     ) -> dict:
         """Fact-check a single news item."""
         # Search for reference material
-        search_context = await self._search_references(item)
+        search_context = await self._search_references(item, session, episode_id)
 
         body_excerpt = ""
         if item.body:

--- a/backend/app/services/brave_search.py
+++ b/backend/app/services/brave_search.py
@@ -23,6 +23,9 @@ class BraveSearchResult:
     age: str | None = None
 
 
+BRAVE_COST_PER_QUERY = 0.005  # $5 per 1,000 queries
+
+
 class BraveSearchService:
     """Brave Search API client for news collection and fact-checking."""
 
@@ -30,6 +33,7 @@ class BraveSearchService:
         self._api_key = api_key or settings.brave_search_api_key
         if not self._api_key:
             raise ValueError("BRAVE_SEARCH_API_KEY is not set")
+        self.query_count: int = 0
 
     async def web_search(
         self,
@@ -115,5 +119,6 @@ class BraveSearchService:
                     )
                 )
 
+        self.query_count += 1
         logger.info("Brave %s search '%s': %d results", search_type, params["q"], len(results))
         return results

--- a/backend/tests/test_brave_search.py
+++ b/backend/tests/test_brave_search.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.services.brave_search import BraveSearchResult, BraveSearchService
+from app.services.brave_search import BRAVE_COST_PER_QUERY, BraveSearchResult, BraveSearchService
 
 
 class TestBraveSearchService:
@@ -97,3 +97,26 @@ class TestBraveSearchService:
         results = await service.web_search("obscure query")
 
         assert results == []
+
+    @patch("app.services.brave_search.httpx.AsyncClient")
+    async def test_query_count_incremented(self, mock_client_cls):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"web": {"results": []}}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        service = BraveSearchService(api_key="test-key")
+        assert service.query_count == 0
+
+        await service.web_search("query1")
+        assert service.query_count == 1
+
+        await service.web_search("query2")
+        assert service.query_count == 2
+
+    def test_cost_per_query_constant(self):
+        assert BRAVE_COST_PER_QUERY == 0.005

--- a/backend/tests/test_collector.py
+++ b/backend/tests/test_collector.py
@@ -7,7 +7,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import NewsItem, StepName
+from app.models import ApiUsage, NewsItem, StepName
 from app.pipeline.collector import CollectorStep
 from app.pipeline.engine import PipelineEngine
 from app.services.brave_search import BraveSearchResult
@@ -57,6 +57,7 @@ class TestCollectorStep:
         with patch("app.services.brave_search.BraveSearchService") as mock_service_cls:
             mock_service = MagicMock()
             mock_service.web_search = AsyncMock(return_value=results)
+            mock_service.query_count = 1
             mock_service_cls.return_value = mock_service
 
             result = await collector.execute(episode.id, {}, session)
@@ -90,6 +91,7 @@ class TestCollectorStep:
         with patch("app.services.brave_search.BraveSearchService") as mock_service_cls:
             mock_service = MagicMock()
             mock_service.web_search = AsyncMock(return_value=results)
+            mock_service.query_count = 1
             mock_service_cls.return_value = mock_service
 
             result1 = await collector.execute(episode.id, {}, session)
@@ -117,6 +119,7 @@ class TestCollectorStep:
         with patch("app.services.brave_search.BraveSearchService") as mock_service_cls:
             mock_service = MagicMock()
             mock_service.web_search = AsyncMock(return_value=[])
+            mock_service.query_count = 1
             mock_service_cls.return_value = mock_service
 
             result = await collector.execute(episode.id, {}, session)
@@ -169,6 +172,7 @@ class TestEnrichment:
             patch("app.services.web_crawler.WebCrawlerService") as mock_crawler_cls,
         ):
             mock_search = MagicMock()
+            mock_search.query_count = 1
             mock_search.web_search = AsyncMock(return_value=_make_brave_results(2))
             mock_search_cls.return_value = mock_search
 
@@ -204,6 +208,7 @@ class TestEnrichment:
 
         with patch("app.services.brave_search.BraveSearchService") as mock_search_cls:
             mock_search = MagicMock()
+            mock_search.query_count = 1
             mock_search.web_search = AsyncMock(return_value=_make_brave_results(1))
             mock_search_cls.return_value = mock_search
 
@@ -243,6 +248,7 @@ class TestEnrichment:
             patch("app.services.web_crawler.WebCrawlerService") as mock_crawler_cls,
         ):
             mock_search = MagicMock()
+            mock_search.query_count = 1
             mock_search.web_search = AsyncMock(return_value=_make_brave_results(1))
             mock_search_cls.return_value = mock_search
 
@@ -313,6 +319,7 @@ class TestAIResearch:
             patch("app.services.ai_provider.get_step_provider", return_value=(mock_provider, "test-model")),
         ):
             mock_search = MagicMock()
+            mock_search.query_count = 1
             mock_search.web_search = AsyncMock(side_effect=[
                 _make_brave_results(1),  # Initial collection
                 additional_search_results,  # AI research additional search
@@ -348,9 +355,52 @@ class TestAIResearch:
 
         with patch("app.services.brave_search.BraveSearchService") as mock_search_cls:
             mock_search = MagicMock()
+            mock_search.query_count = 1
             mock_search.web_search = AsyncMock(return_value=_make_brave_results(1))
             mock_search_cls.return_value = mock_search
 
             result = await collector.execute(episode.id, {}, session)
 
         assert result.get("factcheck_included") is None
+
+
+class TestBraveSearchCostTracking:
+    """Tests for Brave Search API cost tracking in collector."""
+
+    @patch("app.pipeline.collector.settings")
+    async def test_brave_search_records_api_usage(
+        self, mock_settings, collector: CollectorStep, session: AsyncSession
+    ):
+        """Brave Search queries should be recorded as ApiUsage."""
+        mock_settings.collection_method = "brave"
+        mock_settings.collection_queries = "テスト"
+        mock_settings.brave_search_api_key = "test-key"
+        mock_settings.collection_crawl_enabled = False
+        mock_settings.collection_youtube_enabled = False
+        mock_settings.collection_document_enabled = False
+        mock_settings.collection_ai_research_enabled = False
+
+        engine = PipelineEngine()
+        episode = await engine.create_episode("Test", session)
+
+        with patch("app.services.brave_search.BraveSearchService") as mock_service_cls:
+            mock_service = MagicMock()
+            mock_service.web_search = AsyncMock(return_value=_make_brave_results(2))
+            mock_service.query_count = 1
+            mock_service_cls.return_value = mock_service
+
+            await collector.execute(episode.id, {}, session)
+
+        # Verify Brave Search usage recorded
+        db_result = await session.execute(
+            select(ApiUsage).where(
+                ApiUsage.episode_id == episode.id,
+                ApiUsage.provider == "brave",
+            )
+        )
+        usages = db_result.scalars().all()
+        assert len(usages) == 1
+        assert usages[0].model == "brave-search"
+        assert usages[0].input_tokens == 1
+        assert usages[0].output_tokens == 0
+        assert usages[0].cost_usd == pytest.approx(0.005)

--- a/backend/tests/test_factchecker.py
+++ b/backend/tests/test_factchecker.py
@@ -1,7 +1,7 @@
 """Tests for FactcheckerStep pipeline step."""
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import select
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models import ApiUsage, NewsItem, StepName
 from app.pipeline.factchecker import FactcheckerStep
 from app.services.ai_provider import AIResponse
+from app.services.brave_search import BraveSearchResult
 from tests.helpers import create_episode_with_items
 
 
@@ -139,10 +140,12 @@ class TestFactcheckerStep:
 
         await factchecker.execute(episode_id, {}, session)
 
+        # Check AI provider usages (excludes Brave Search usages)
         db_result = await session.execute(
             select(ApiUsage).where(
                 ApiUsage.episode_id == episode_id,
                 ApiUsage.step_name == "factcheck",
+                ApiUsage.provider != "brave",
             )
         )
         usages = db_result.scalars().all()
@@ -234,3 +237,46 @@ class TestFactcheckerSkipPath:
         assert "factcheck_source" not in result
         assert result["items_checked"] == 1
         mock_provider.generate.assert_called_once()
+
+
+class TestBraveSearchCostTracking:
+    """Tests for Brave Search cost tracking in factchecker."""
+
+    @patch("app.pipeline.factchecker.get_step_provider")
+    async def test_brave_search_records_api_usage(
+        self,
+        mock_get_provider,
+        factchecker: FactcheckerStep,
+        session: AsyncSession,
+    ):
+        """Brave Search queries in fact-checking should be recorded as ApiUsage."""
+        episode_id, _ = await create_episode_with_items(session, 1)
+
+        mock_provider = AsyncMock()
+        mock_provider.generate.return_value = _make_ai_response()
+        mock_get_provider.return_value = (mock_provider, "test-model")
+
+        brave_results = [
+            BraveSearchResult(title="Ref", url="https://ref.example.com", description="Reference"),
+        ]
+
+        with patch("app.services.brave_search.BraveSearchService") as mock_search_cls:
+            mock_search = MagicMock()
+            mock_search.web_search = AsyncMock(return_value=brave_results)
+            mock_search_cls.return_value = mock_search
+
+            await factchecker.execute(episode_id, {}, session)
+
+        # Verify Brave Search usage recorded
+        db_result = await session.execute(
+            select(ApiUsage).where(
+                ApiUsage.episode_id == episode_id,
+                ApiUsage.provider == "brave",
+            )
+        )
+        usages = db_result.scalars().all()
+        assert len(usages) == 1
+        assert usages[0].model == "brave-search"
+        assert usages[0].input_tokens == 1
+        assert usages[0].output_tokens == 0
+        assert usages[0].cost_usd == pytest.approx(0.005)


### PR DESCRIPTION
## Summary
- Brave Search APIクエリのコストを`api_usages`テーブルに記録し、コストダッシュボードで可視化可能にする
- 収集ステップ（初期検索＋AIリサーチ）とファクトチェックステップ（裏取り検索）の両方で記録
- `model_pricing`テーブルにBrave Search料金データを追加（$5/1,000クエリ = $0.005/クエリ）

## Changes
- `brave_search.py`: `BRAVE_COST_PER_QUERY`定数と`query_count`カウンターを追加
- `collector.py`: `_collect_brave()`と`_ai_research()`でBrave Search使用量を`record_usage`で記録
- `factchecker.py`: `_search_references()`でBrave Search使用量を`record_usage`で記録
- `013_add_brave_search_pricing.py`: マイグレーションでbrave-searchの料金データを追加
- テスト: 各ステップのBrave Searchコスト記録テストを追加（全208テストpass）

## Test plan
- [x] `test_brave_search.py`: query_countインクリメントとコスト定数テスト追加
- [x] `test_collector.py`: Brave Search APIコスト記録テスト追加
- [x] `test_factchecker.py`: Brave Search APIコスト記録テスト追加
- [x] 全208テストpass

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)