### PR TITLE
fix: TTS/Imagenのコスト記録をAIプロバイダーと区別

### DIFF
--- a/backend/app/pipeline/video.py
+++ b/backend/app/pipeline/video.py
@@ -124,7 +124,7 @@ class VideoStep(BaseStep):
             await self.record_usage(
                 session=session,
                 episode_id=episode_id,
-                provider="google",
+                provider="google-imagen",
                 model=settings.visual_imagen_model,
                 input_tokens=0,
                 output_tokens=0,

--- a/backend/app/pipeline/voice.py
+++ b/backend/app/pipeline/voice.py
@@ -167,7 +167,7 @@ class VoiceStep(BaseStep):
             await self.record_usage(
                 session=session,
                 episode_id=episode_id,
-                provider=provider_name,
+                provider=f"{provider_name}-tts" if provider_name == "google" else provider_name,
                 model=model_name,
                 input_tokens=total_chars,
                 output_tokens=0,


### PR DESCRIPTION
## Summary

- Google TTS のコスト記録を `provider="google-tts"` に変更
- Imagen のコスト記録を `provider="google-imagen"` に変更
- テキスト生成AI (`provider="google"`) と混同されなくなる

Closes #69

## Test plan

- [ ] Google TTS で音声生成し、`api_usage` テーブルの provider が `google-tts` になることを確認
- [ ] Imagen で画像生成し、`api_usage` テーブルの provider が `google-imagen` になることを確認
- [ ] コストダッシュボードで TTS/Imagen が別行で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)