### PR TITLE
feat: エピソード詳細にコスト合計を表示

### DIFF
--- a/frontend/src/components/EpisodeDetail.tsx
+++ b/frontend/src/components/EpisodeDetail.tsx
@@ -144,6 +144,7 @@ export default function EpisodeDetail() {
   const [titleDraft, setTitleDraft] = useState("");
   const [ttsModel, setTtsModel] = useState("");
   const [ttsVoice, setTtsVoice] = useState("");
+  const [totalCost, setTotalCost] = useState<number | null>(null);
 
   useEffect(() => {
     api.getSettings().then((res) => {
@@ -151,6 +152,12 @@ export default function EpisodeDetail() {
       setDriveEnabled(val.toLowerCase() === "true");
     }).catch(() => {});
   }, []);
+
+  useEffect(() => {
+    api.getEpisodeCosts(episodeId).then((res) => {
+      setTotalCost(res.data.total_cost_usd);
+    }).catch(() => {});
+  }, [episodeId]);
 
   if (loading) return <p className="text-gray-500">{t("episode.loading")}</p>;
   if (error) return <p className="text-red-600">{error}</p>;
@@ -292,6 +299,14 @@ export default function EpisodeDetail() {
           <p className="text-sm text-gray-500 mt-1">
             {t("episode.id")}: #{episode.id} / {t("episode.status")}: {t(`episodeStatus.${episode.status}`)} / {t("episode.createdAt")}:{" "}
             {new Date(episode.created_at).toLocaleDateString("ja-JP")}
+            {totalCost !== null && totalCost > 0 && (
+              <>
+                {" / "}
+                <Link to="/costs" className="text-blue-600 hover:text-blue-800 hover:underline" title={t("episode.viewCostDetails")}>
+                  {t("episode.totalCost")}: ${totalCost.toFixed(4)}
+                </Link>
+              </>
+            )}
           </p>
         </div>
         <div className="flex items-center gap-2">

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -70,7 +70,9 @@
     "voiceDefault": "Default",
     "voiceProvider": "Provider",
     "voiceDuration": "Duration",
-    "voiceSections": "Sections"
+    "voiceSections": "Sections",
+    "totalCost": "Total Cost",
+    "viewCostDetails": "Cost Details"
   },
   "approval": {
     "title": "Approval Gate",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -70,7 +70,9 @@
     "voiceDefault": "デフォルト",
     "voiceProvider": "プロバイダー",
     "voiceDuration": "再生時間",
-    "voiceSections": "セクション"
+    "voiceSections": "セクション",
+    "totalCost": "合計コスト",
+    "viewCostDetails": "コスト詳細"
   },
   "approval": {
     "title": "承認ゲート",


### PR DESCRIPTION
## Summary

- エピソード詳細画面のヘッダーにコスト合計を表示（コスト > 0 の場合のみ）
- 既存の未使用だった `getEpisodeCosts` APIメソッドを活用
- コスト統計ページ `/costs` へのリンクを追加
- en.json / ja.json にローカライズキーを追加

Closes #96

## コスト追跡の精査結果

- ハードコードされたコスト（Imagen $0.04/image, Brave $0.005/query）はトークンベースでない課金のため現状維持が妥当
- VOICEVOX はローカル実行で無料のためコスト記録スキップは正しい動作
- ステップ再実行時のコスト加算は正しい動作（#94 クローズ済み）

## Test plan

- [ ] エピソード詳細画面でコスト合計が表示されることを確認
- [ ] コスト0のエピソードではコスト表示が出ないことを確認
- [ ] コスト金額クリックで `/costs` ページに遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)