### PR TITLE
fix: SRT字幕タイミング精度を改善

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -85,6 +85,7 @@ class Settings(BaseSettings):
     # Video overlay styling
     video_border_color: str = "#DC1E1E"  # Hex color for thumbnail/video border
     video_logo_path: str = ""  # Path to logo image (replaces "AI NEWS RADIO" text badge)
+    video_logo_enabled: bool = True  # Show logo/text badge on thumbnail & video
 
     # YouTube CTA (Call To Action) after opening
     youtube_cta_enabled: bool = True

--- a/backend/app/pipeline/video.py
+++ b/backend/app/pipeline/video.py
@@ -379,17 +379,28 @@ class VideoStep(BaseStep):
                 section_texts[f"transition_{i}"] = t
 
         # Build SRT entries
-        # First pass: compute raw timings using reported durations + silence gap
+        # Use precise start_at/end_at from voice step when available,
+        # fall back to cumulative calculation for backward compatibility
         silence_gap = settings.voice_section_silence
         raw_entries: list[tuple[float, float, str]] = []
-        elapsed = 0.0
+        fallback_elapsed = 0.0
 
         for sec in voice_sections:
             key = sec.get("key", "")
             duration = sec.get("duration_seconds", 0.0)
             text = section_texts.get(key, "")
 
-            if text and duration > 0:
+            # Determine section start/end: prefer precise timestamps
+            if "start_at" in sec and "end_at" in sec:
+                section_start = sec["start_at"]
+                section_end = sec["end_at"]
+                section_duration = section_end - section_start
+            else:
+                section_start = fallback_elapsed
+                section_duration = duration
+                section_end = section_start + section_duration
+
+            if text and section_duration > 0:
                 # Remove reading hints like （けんぐん） or (けんぐん) from display text
                 display = re.sub(r'[（\(][ぁ-んー]+[）\)]', '', text)
 
@@ -405,10 +416,10 @@ class VideoStep(BaseStep):
                 if total_chars == 0:
                     total_chars = 1
 
-                sub_elapsed = elapsed
+                sub_elapsed = section_start
                 for sentence in sentences:
                     ratio = len(sentence) / total_chars
-                    sub_duration = duration * ratio
+                    sub_duration = section_duration * ratio
                     # Limit subtitle length for readability
                     display_text = sentence
                     if len(display_text) > 40:
@@ -425,7 +436,7 @@ class VideoStep(BaseStep):
                     raw_entries.append((sub_elapsed, sub_elapsed + sub_duration, display_text))
                     sub_elapsed += sub_duration
 
-            elapsed += duration + silence_gap
+            fallback_elapsed += duration + silence_gap
 
         # Apply fixed offset to all SRT timestamps (positive = subtitles appear later)
         offset = settings.srt_offset
@@ -504,23 +515,24 @@ class VideoStep(BaseStep):
         )
 
         # --- Logo or "AI NEWS RADIO" badge — top-left ---
-        badge_pad = border_width + 12
-        logo_path = settings.video_logo_path
-        if logo_path and os.path.exists(logo_path):
-            # Use custom logo image
-            try:
-                logo = Image.open(logo_path).convert("RGBA")
-                # Scale logo to fit badge area (height ~10% of image)
-                logo_max_h = int(h * 0.10)
-                ratio = logo_max_h / logo.height
-                logo_w = int(logo.width * ratio)
-                logo = logo.resize((logo_w, logo_max_h), Image.Resampling.LANCZOS)
-                overlay.paste(logo, (badge_pad, badge_pad), logo)
-            except Exception as e:
-                logger.warning("Logo load failed, falling back to text badge: %s", e)
+        if settings.video_logo_enabled:
+            badge_pad = border_width + 12
+            logo_path = settings.video_logo_path
+            if logo_path and os.path.exists(logo_path):
+                # Use custom logo image
+                try:
+                    logo = Image.open(logo_path).convert("RGBA")
+                    # Scale logo to fit badge area (height ~10% of image)
+                    logo_max_h = int(h * 0.10)
+                    ratio = logo_max_h / logo.height
+                    logo_w = int(logo.width * ratio)
+                    logo = logo.resize((logo_w, logo_max_h), Image.Resampling.LANCZOS)
+                    overlay.paste(logo, (badge_pad, badge_pad), logo)
+                except Exception as e:
+                    logger.warning("Logo load failed, falling back to text badge: %s", e)
+                    self._draw_text_badge(draw_overlay, badge_pad, h, border_color_fill)
+            else:
                 self._draw_text_badge(draw_overlay, badge_pad, h, border_color_fill)
-        else:
-            self._draw_text_badge(draw_overlay, badge_pad, h, border_color_fill)
 
         img = Image.alpha_composite(img, overlay)
         draw = ImageDraw.Draw(img)

--- a/backend/app/pipeline/voice.py
+++ b/backend/app/pipeline/voice.py
@@ -102,6 +102,7 @@ class VoiceStep(BaseStep):
         silence_chunk: bytes | None = None  # Generated after first section (to match sample rate)
         total_chars = 0
         sample_rate = 24000  # Default; updated after first TTS output
+        elapsed = 0.0  # Cumulative time tracking for accurate SRT timestamps
 
         for i, section in enumerate(sections):
             tts_text = self._prepare_tts_text(section["text"], pronunciations)
@@ -139,6 +140,7 @@ class VoiceStep(BaseStep):
                 se_intro = load_se(settings.se_intro, sample_rate)
                 if se_intro:
                     all_audio_chunks.append(se_intro)
+                    elapsed += self._get_audio_duration(se_intro, audio_format)
                     logger.info("Episode %d: inserted intro SE '%s'", episode_id, settings.se_intro)
 
             # Save individual section audio
@@ -148,11 +150,18 @@ class VoiceStep(BaseStep):
                 f.write(audio_bytes)
 
             duration = self._get_audio_duration(audio_bytes, audio_format)
+
+            # Record precise start/end timestamps for this section
+            section_start = elapsed
+            elapsed += duration
+
             section_results.append({
                 "key": section["key"],
                 "label": section["label"],
                 "file": f"{episode_id}/{section_filename}",
                 "duration_seconds": round(duration, 2),
+                "start_at": round(section_start, 3),
+                "end_at": round(elapsed, 3),
                 **({"news_item_id": section["news_item_id"]} if "news_item_id" in section else {}),
             })
 
@@ -171,15 +180,18 @@ class VoiceStep(BaseStep):
                     se_trans = load_se(settings.se_transition, sample_rate)
                     if se_trans:
                         all_audio_chunks.append(se_trans)
+                        elapsed += self._get_audio_duration(se_trans, audio_format)
                         inserted_se = True
                 if not inserted_se and silence_chunk:
                     all_audio_chunks.append(silence_chunk)
+                    elapsed += _silence_seconds()
 
         # Insert outro SE after the last section
         if audio_format == "wav":
             se_outro = load_se(settings.se_outro, sample_rate)
             if se_outro:
                 all_audio_chunks.append(se_outro)
+                elapsed += self._get_audio_duration(se_outro, audio_format)
                 logger.info("Episode %d: inserted outro SE '%s'", episode_id, settings.se_outro)
 
         # Concatenate all sections into combined audio
@@ -284,20 +296,25 @@ class VoiceStep(BaseStep):
     def _build_timestamps(self, section_results: list[dict]) -> str:
         """Build YouTube-style timestamps from section durations.
 
-        Accounts for silence gaps between sections.
+        Uses precise start_at timestamps when available, falls back to
+        cumulative calculation with silence gaps.
         """
         lines: list[str] = []
         elapsed = 0.0
 
         for i, section in enumerate(section_results):
+            # Use precise start_at if available, otherwise fall back to elapsed
+            pos = section.get("start_at", elapsed)
+
             # Skip transitions in timestamps (not useful for YouTube index)
             if not section["key"].startswith("transition_"):
-                minutes = int(elapsed // 60)
-                seconds = int(elapsed % 60)
+                minutes = int(pos // 60)
+                seconds = int(pos % 60)
                 timestamp = f"{minutes}:{seconds:02d}"
                 lines.append(f"{timestamp} {section['label']}")
+
+            # Update fallback elapsed (for data without start_at)
             elapsed += section["duration_seconds"]
-            # Add silence gap (except after last section)
             if i < len(section_results) - 1:
                 elapsed += _silence_seconds()
 


### PR DESCRIPTION
## Summary
- voice.pyで音声結合時にSE・サイレンスの実際の長さを計測し、各セクションの正確な`start_at`/`end_at`を`section_results`に記録
- video.pyのSRT生成で`start_at`/`end_at`を優先使用（後方互換フォールバック付き）
- `video_logo_enabled`設定を追加し、ロゴ/テキストバッジの表示を制御可能に

Closes #95

## Test plan
- [x] Episode 4でvoice→video再実行し、SRT字幕が音声と同期していることを確認
- [x] SE有効時にタイミングが正確であることを確認（intro SE 1.35s分のオフセットが反映）
- [x] `srt_offset`設定が引き続き機能することを確認
- [x] `start_at`がない古いデータでもフォールバック動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)