### PR TITLE
feat: Phase 1 - スピーカープロファイル・分析推奨・台本モード基盤

### DIFF
--- a/backend/alembic/versions/017_add_speaker_profiles_and_script_mode.py
+++ b/backend/alembic/versions/017_add_speaker_profiles_and_script_mode.py
@@ -1,0 +1,80 @@
+"""Add speaker_profiles table, script_mode/script_data to news_items, shorts_enabled to episodes
+
+Revision ID: 017
+Revises: 016
+Create Date: 2026-03-16
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "017"
+down_revision = "016"
+branch_labels = None
+depends_on = None
+
+DEFAULT_SPEAKERS = [
+    {
+        "name": "レイナ",
+        "role": "anchor",
+        "voice_name": "Kore",
+        "voice_instructions": "落ち着いたニュースキャスターのように、明瞭で聞き取りやすく話してください。テンポよく、信頼感のあるトーンで。",
+        "avatar_position": "right",
+        "description": "メインMC。番組の進行役として、ニュースの導入や話題の切り替えを担当。",
+    },
+    {
+        "name": "タクヤ",
+        "role": "expert",
+        "voice_name": "Charon",
+        "voice_instructions": "知的で分析的なトーンで話してください。専門家として自信を持ちつつも、わかりやすく丁寧に解説する口調で。",
+        "avatar_position": "left",
+        "description": "解説者。ニュースの背景や複数の視点を深掘りし、専門的な分析を提供。",
+    },
+    {
+        "name": "アオイ",
+        "role": "narrator",
+        "voice_name": "Aoede",
+        "voice_instructions": "自然な語りのトーンで、聞きやすいペースで話してください。感情を込めすぎず、落ち着いたナレーションで。",
+        "avatar_position": "right",
+        "description": "ソロナレーター。1人でニュースの要点から分析まで通して伝える。",
+    },
+]
+
+
+def upgrade() -> None:
+    op.create_table(
+        "speaker_profiles",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("role", sa.String(50), nullable=False, unique=True),
+        sa.Column("voice_name", sa.String(50), server_default="Kore"),
+        sa.Column("voice_instructions", sa.Text(), server_default=""),
+        sa.Column("avatar_path", sa.String(500), nullable=True),
+        sa.Column("avatar_position", sa.String(10), server_default="right"),
+        sa.Column("description", sa.Text(), server_default=""),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    # Seed default speakers
+    for s in DEFAULT_SPEAKERS:
+        op.execute(
+            "INSERT INTO speaker_profiles (name, role, voice_name, voice_instructions, avatar_position, description) "
+            f"VALUES ('{s['name']}', '{s['role']}', '{s['voice_name']}', "
+            f"'{s['voice_instructions']}', '{s['avatar_position']}', '{s['description']}')"
+        )
+
+    op.add_column("news_items", sa.Column("script_mode", sa.String(20), nullable=True))
+    op.add_column("news_items", sa.Column("script_data", sa.JSON(), nullable=True))
+
+    op.add_column(
+        "episodes",
+        sa.Column("shorts_enabled", sa.Boolean(), server_default="false", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("episodes", "shorts_enabled")
+    op.drop_column("news_items", "script_data")
+    op.drop_column("news_items", "script_mode")
+    op.drop_table("speaker_profiles")

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -135,6 +135,8 @@ class NewsItemResponse(BaseModel):
     reference_urls: list[str] | None = None
     analysis_data: dict | None = None
     script_text: str | None = None
+    script_mode: str | None = None
+    script_data: dict | None = None
     group_id: int | None = None
     is_group_primary: bool | None = None
     excluded: bool = False

--- a/backend/app/api/speakers.py
+++ b/backend/app/api/speakers.py
@@ -1,0 +1,170 @@
+"""Speaker profiles CRUD API."""
+
+import os
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import get_session
+from app.models.speaker_profile import SpeakerProfile
+
+router = APIRouter(tags=["speakers"])
+
+
+class SpeakerCreate(BaseModel):
+    """Request body for creating/updating a speaker profile."""
+
+    name: str
+    role: str
+    voice_name: str = "Kore"
+    voice_instructions: str = ""
+    avatar_position: str = "right"
+    description: str = ""
+
+
+class SpeakerResponse(BaseModel):
+    """Response for a speaker profile."""
+
+    id: int
+    name: str
+    role: str
+    voice_name: str
+    voice_instructions: str
+    avatar_path: str | None
+    avatar_position: str
+    description: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+@router.get("/speakers")
+async def list_speakers(session: AsyncSession = Depends(get_session)) -> list[SpeakerResponse]:
+    """List all speaker profiles."""
+    result = await session.execute(select(SpeakerProfile).order_by(SpeakerProfile.id))
+    return [SpeakerResponse.model_validate(s) for s in result.scalars()]
+
+
+@router.post("/speakers")
+async def create_speaker(
+    body: SpeakerCreate, session: AsyncSession = Depends(get_session)
+) -> SpeakerResponse:
+    """Create a new speaker profile."""
+    # Validate role uniqueness
+    existing = await session.execute(
+        select(SpeakerProfile).where(SpeakerProfile.role == body.role)
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail=f"Role '{body.role}' is already assigned to another speaker")
+
+    speaker = SpeakerProfile(
+        name=body.name,
+        role=body.role,
+        voice_name=body.voice_name,
+        voice_instructions=body.voice_instructions,
+        avatar_position=body.avatar_position,
+        description=body.description,
+    )
+    session.add(speaker)
+    await session.commit()
+    await session.refresh(speaker)
+    return SpeakerResponse.model_validate(speaker)
+
+
+@router.put("/speakers/{speaker_id}")
+async def update_speaker(
+    speaker_id: int, body: SpeakerCreate, session: AsyncSession = Depends(get_session)
+) -> SpeakerResponse:
+    """Update an existing speaker profile."""
+    result = await session.execute(select(SpeakerProfile).where(SpeakerProfile.id == speaker_id))
+    speaker = result.scalar_one_or_none()
+    if not speaker:
+        raise HTTPException(status_code=404, detail="Speaker not found")
+
+    # Validate role uniqueness (exclude self)
+    existing = await session.execute(
+        select(SpeakerProfile).where(
+            SpeakerProfile.role == body.role, SpeakerProfile.id != speaker_id
+        )
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail=f"Role '{body.role}' is already assigned to another speaker")
+
+    speaker.name = body.name
+    speaker.role = body.role
+    speaker.voice_name = body.voice_name
+    speaker.voice_instructions = body.voice_instructions
+    speaker.avatar_position = body.avatar_position
+    speaker.description = body.description
+    await session.commit()
+    await session.refresh(speaker)
+    return SpeakerResponse.model_validate(speaker)
+
+
+@router.delete("/speakers/{speaker_id}")
+async def delete_speaker(
+    speaker_id: int, session: AsyncSession = Depends(get_session)
+) -> dict:
+    """Delete a speaker profile."""
+    result = await session.execute(select(SpeakerProfile).where(SpeakerProfile.id == speaker_id))
+    speaker = result.scalar_one_or_none()
+    if not speaker:
+        raise HTTPException(status_code=404, detail="Speaker not found")
+
+    await session.delete(speaker)
+    await session.commit()
+    return {"deleted": True}
+
+
+@router.post("/speakers/{speaker_id}/avatar")
+async def upload_avatar(
+    speaker_id: int,
+    file: UploadFile,
+    session: AsyncSession = Depends(get_session),
+) -> SpeakerResponse:
+    """Upload an avatar image for a speaker."""
+    result = await session.execute(select(SpeakerProfile).where(SpeakerProfile.id == speaker_id))
+    speaker = result.scalar_one_or_none()
+    if not speaker:
+        raise HTTPException(status_code=404, detail="Speaker not found")
+
+    if not file.content_type or not file.content_type.startswith("image/"):
+        raise HTTPException(status_code=400, detail="Only image files are accepted")
+
+    avatar_dir = os.path.join(settings.media_dir, "avatars")
+    os.makedirs(avatar_dir, exist_ok=True)
+    avatar_path = os.path.join(avatar_dir, f"speaker_{speaker_id}.png")
+
+    content = await file.read()
+    with open(avatar_path, "wb") as f:
+        f.write(content)
+
+    speaker.avatar_path = avatar_path
+    await session.commit()
+    await session.refresh(speaker)
+    return SpeakerResponse.model_validate(speaker)
+
+
+@router.delete("/speakers/{speaker_id}/avatar")
+async def delete_avatar(
+    speaker_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> SpeakerResponse:
+    """Remove avatar from a speaker."""
+    result = await session.execute(select(SpeakerProfile).where(SpeakerProfile.id == speaker_id))
+    speaker = result.scalar_one_or_none()
+    if not speaker:
+        raise HTTPException(status_code=404, detail="Speaker not found")
+
+    if speaker.avatar_path and os.path.exists(speaker.avatar_path):
+        os.remove(speaker.avatar_path)
+
+    speaker.avatar_path = None
+    await session.commit()
+    await session.refresh(speaker)
+    return SpeakerResponse.model_validate(speaker)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -114,6 +114,10 @@ class Settings(BaseSettings):
     pipeline_export_provider: str = ""
     pipeline_export_model: str = ""
 
+    # Script mode (multi-speaker)
+    script_default_mode: str = "auto"  # auto / explainer / solo
+    shorts_max_duration_seconds: int = 30
+
     model_config = {"env_file": ".env", "extra": "ignore"}
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from app.api.pricing import router as pricing_router
 from app.api.prompts import router as prompts_router
 from app.api.search import router as search_router
 from app.api.settings import router as settings_router
+from app.api.speakers import router as speakers_router
 from app.api.stats import router as stats_router
 from app.config import settings
 
@@ -68,6 +69,7 @@ app.include_router(search_router, prefix="/api")
 app.include_router(prompts_router, prefix="/api")
 app.include_router(settings_router, prefix="/api")
 app.include_router(dictionary_router, prefix="/api")
+app.include_router(speakers_router, prefix="/api")
 app.include_router(google_auth_router, prefix="/api")
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,6 +7,7 @@ from app.models.news_item import NewsItem
 from app.models.pipeline_step import PipelineStep, StepName, StepStatus
 from app.models.prompt_template import PromptTemplate
 from app.models.pronunciation import Pronunciation
+from app.models.speaker_profile import SpeakerProfile
 
 __all__ = [
     "ApiUsage",
@@ -19,6 +20,7 @@ __all__ = [
     "PipelineStep",
     "PromptTemplate",
     "Pronunciation",
+    "SpeakerProfile",
     "StepName",
     "StepStatus",
 ]

--- a/backend/app/models/episode.py
+++ b/backend/app/models/episode.py
@@ -1,7 +1,7 @@
 import enum
 from datetime import datetime
 
-from sqlalchemy import DateTime, Enum, String, func
+from sqlalchemy import Boolean, DateTime, Enum, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
@@ -28,6 +28,7 @@ class Episode(Base):
     video_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
     drive_file_id: Mapped[str | None] = mapped_column(String(200), nullable=True)
     drive_file_url: Mapped[str | None] = mapped_column(String(2000), nullable=True)
+    shorts_enabled: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
 
     news_items: Mapped[list["NewsItem"]] = relationship(back_populates="episode", cascade="all, delete-orphan")
     pipeline_steps: Mapped[list["PipelineStep"]] = relationship(back_populates="episode", cascade="all, delete-orphan")

--- a/backend/app/models/news_item.py
+++ b/backend/app/models/news_item.py
@@ -37,6 +37,8 @@ class NewsItem(Base):
 
     # Script
     script_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    script_mode: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    script_data: Mapped[dict | None] = mapped_column(JSON, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 

--- a/backend/app/models/speaker_profile.py
+++ b/backend/app/models/speaker_profile.py
@@ -1,0 +1,23 @@
+"""SpeakerProfile model for managing speaker/character settings."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class SpeakerProfile(Base):
+    __tablename__ = "speaker_profiles"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100))
+    role: Mapped[str] = mapped_column(String(50), unique=True)
+    voice_name: Mapped[str] = mapped_column(String(50), server_default="Kore")
+    voice_instructions: Mapped[str] = mapped_column(Text, server_default="")
+    avatar_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    avatar_position: Mapped[str] = mapped_column(String(10), server_default="right")
+    description: Mapped[str] = mapped_column(Text, server_default="")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/backend/app/pipeline/analyzer.py
+++ b/backend/app/pipeline/analyzer.py
@@ -43,8 +43,14 @@ ANALYSIS_SYSTEM_PROMPT = """\
   "impact": "一般市民の生活への具体的な影響",
   "uncertainties": "不確実な点、確認できない点",
   "severity": "high または medium または low（ニュースの重要度）",
-  "topics": ["関連トピックタグ1", "関連トピックタグ2"]
-}"""
+  "topics": ["関連トピックタグ1", "関連トピックタグ2"],
+  "recommended_format": "explainer または solo（推奨される台本フォーマット）",
+  "format_reason": "推奨理由の簡潔な説明"
+}
+
+recommended_format の判定基準:
+- 専門的・技術的テーマ、背景説明が多い、複数視点あり、データ検証が必要 → "explainer"（MC＋解説者の2人対話形式）
+- 速報・シンプルなニュース、単一視点で十分、短い報告 → "solo"（1人ナレーション）"""
 
 ANALYSIS_GROUPING_SYSTEM_PROMPT = """\
 あなたはニュース記事の類似性を判定する専門家です。
@@ -103,8 +109,14 @@ ANALYSIS_GROUP_SYSTEM_PROMPT = """\
   "uncertainties": "不確実な点、確認できない点",
   "source_comparison": "各ソース間の報道の一致点・相違点",
   "severity": "high または medium または low（ニュースの重要度）",
-  "topics": ["関連トピックタグ1", "関連トピックタグ2"]
-}"""
+  "topics": ["関連トピックタグ1", "関連トピックタグ2"],
+  "recommended_format": "explainer または solo（推奨される台本フォーマット）",
+  "format_reason": "推奨理由の簡潔な説明"
+}
+
+recommended_format の判定基準:
+- 専門的・技術的テーマ、背景説明が多い、複数視点あり、ソース間の比較が必要 → "explainer"（MC＋解説者の2人対話形式）
+- 速報・シンプルなニュース、単一視点で十分、短い報告 → "solo"（1人ナレーション）"""
 
 register_default(PROMPT_KEY, ANALYSIS_SYSTEM_PROMPT)
 register_default(PROMPT_KEY_GROUPING, ANALYSIS_GROUPING_SYSTEM_PROMPT)

--- a/backend/app/pipeline/scriptwriter.py
+++ b/backend/app/pipeline/scriptwriter.py
@@ -5,8 +5,8 @@ import logging
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings
 from app.models import NewsItem, StepName
+from app.models.speaker_profile import SpeakerProfile
 from app.pipeline.base import BaseStep
 from app.pipeline.utils import parse_json_response
 from app.services.ai_provider import get_step_provider
@@ -157,13 +157,16 @@ class ScriptwriterStep(BaseStep):
         item_prompt, item_prompt_version = await get_active_prompt(session, PROMPT_KEY_ITEM)
         episode_prompt, episode_prompt_version = await get_active_prompt(session, PROMPT_KEY_EPISODE)
 
-        # Inject TTS voice style instructions into script prompts
-        tts_instructions = settings.gemini_tts_instructions
-        if tts_instructions and settings.pipeline_voice_provider == "gemini":
+        # Inject TTS voice style instructions from speaker profiles
+        narrator = await session.execute(
+            select(SpeakerProfile).where(SpeakerProfile.role == "narrator")
+        )
+        narrator_profile = narrator.scalar_one_or_none()
+        if narrator_profile and narrator_profile.voice_instructions:
             tts_hint = (
                 f"\n\n## 音声スタイルへの最適化\n"
                 f"この台本は以下の指示で音声合成されます。この話し方に合った文体・リズム・語尾で書いてください:\n"
-                f"「{tts_instructions}」"
+                f"「{narrator_profile.voice_instructions}」"
             )
             item_prompt += tts_hint
             episode_prompt += tts_hint

--- a/backend/app/services/tts_gemini.py
+++ b/backend/app/services/tts_gemini.py
@@ -34,11 +34,16 @@ class GeminiTTSProvider(TTSProvider):
     via natural language instructions (no SSML needed).
     """
 
-    def __init__(self, model: str | None = None, voice: str | None = None) -> None:
+    def __init__(
+        self,
+        model: str | None = None,
+        voice: str | None = None,
+        instructions: str | None = None,
+    ) -> None:
         self._client = genai.Client(api_key=settings.google_api_key)
         self._model = model or settings.gemini_tts_model
         self._voice = voice or settings.gemini_tts_voice
-        self._instructions = settings.gemini_tts_instructions
+        self._instructions = instructions if instructions is not None else settings.gemini_tts_instructions
         # Accumulated token usage across synthesize() calls
         self.total_input_tokens = 0
         self.total_output_tokens = 0

--- a/backend/app/services/tts_provider.py
+++ b/backend/app/services/tts_provider.py
@@ -29,13 +29,16 @@ class TTSProvider(ABC):
 
 
 def get_tts_provider(
-    model: str | None = None, voice: str | None = None
+    model: str | None = None,
+    voice: str | None = None,
+    instructions: str | None = None,
 ) -> TTSProvider:
     """Factory function to get a TTS provider based on settings.
 
     Args:
         model: Override TTS model (provider-specific).
         voice: Override TTS voice name.
+        instructions: Override voice style instructions (Gemini TTS only).
     """
     provider_name = settings.pipeline_voice_provider
 
@@ -58,6 +61,6 @@ def get_tts_provider(
     elif provider_name == "gemini":
         from app.services.tts_gemini import GeminiTTSProvider
 
-        return GeminiTTSProvider(model=model, voice=voice)
+        return GeminiTTSProvider(model=model, voice=voice, instructions=instructions)
     else:
         raise ValueError(f"Unknown TTS provider: {provider_name}")

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -14,6 +14,7 @@ import type {
   PromptTemplateVersion,
   DriveExportResponse,
   AppSettings,
+  SpeakerProfile,
 } from "../types";
 
 const client = axios.create({
@@ -80,6 +81,19 @@ export const api = {
   getSettings: () => client.get<AppSettings>("/settings"),
   updateSettings: (settings: Record<string, string>) =>
     client.put<{ updated: string[] }>("/settings", { settings }),
+  // Speakers
+  getSpeakers: () => client.get<SpeakerProfile[]>("/speakers"),
+  createSpeaker: (data: { name: string; role: string; voice_name?: string; voice_instructions?: string; avatar_position?: string; description?: string }) =>
+    client.post<SpeakerProfile>("/speakers", data),
+  updateSpeaker: (id: number, data: { name: string; role: string; voice_name?: string; voice_instructions?: string; avatar_position?: string; description?: string }) =>
+    client.put<SpeakerProfile>(`/speakers/${id}`, data),
+  deleteSpeaker: (id: number) => client.delete(`/speakers/${id}`),
+  uploadAvatar: (id: number, file: File) => {
+    const form = new FormData();
+    form.append("file", file);
+    return client.post<SpeakerProfile>(`/speakers/${id}/avatar`, form);
+  },
+  deleteAvatar: (id: number) => client.delete<SpeakerProfile>(`/speakers/${id}/avatar`),
   // Toggle complete
   toggleComplete: (episodeId: number) =>
     client.post<Episode>(`/episodes/${episodeId}/toggle-complete`),

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1,15 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { api } from "../api/client";
-import type { ModelPricing, Pronunciation, PromptSummary, PromptHistory } from "../types";
+import type { ModelPricing, Pronunciation, PromptSummary, PromptHistory, SpeakerProfile } from "../types";
 import {
   GEMINI_TTS_MODEL_VALUES,
   GEMINI_TTS_MODEL_LABELS,
-  GEMINI_TTS_VOICE_VALUES,
-  GEMINI_TTS_VOICE_LABELS,
+  GEMINI_TTS_VOICES,
 } from "../constants/tts";
 
-type SettingsTab = "config" | "pricing" | "prompts" | "dictionary";
+type SettingsTab = "config" | "speakers" | "pricing" | "prompts" | "dictionary";
 
 export default function Settings() {
   const { t } = useTranslation();
@@ -17,6 +16,7 @@ export default function Settings() {
 
   const tabs: { key: SettingsTab; label: string }[] = [
     { key: "config", label: t("settings.config.title") },
+    { key: "speakers", label: t("settings.speakers.title") },
     { key: "pricing", label: t("settings.pricing.title") },
     { key: "prompts", label: t("settings.prompts.title") },
     { key: "dictionary", label: t("settings.dictionary.title") },
@@ -44,6 +44,7 @@ export default function Settings() {
       </div>
 
       {activeTab === "config" && <ConfigSection />}
+      {activeTab === "speakers" && <SpeakersSection />}
       {activeTab === "pricing" && <PricingSection />}
       {activeTab === "prompts" && <PromptsSection />}
       {activeTab === "dictionary" && <DictionarySection />}
@@ -164,16 +165,7 @@ function ConfigSection() {
       fields: [
         { key: "voice_section_silence", label: t("settings.config.fields.voice_section_silence"), type: "number" },
         { key: "srt_offset", label: t("settings.config.fields.srt_offset"), type: "number" },
-        { key: "pipeline_voice_provider", label: t("settings.config.fields.pipeline_voice_provider"), type: "select", options: ["voicevox", "openai", "elevenlabs", "google", "gemini"], optionLabels: { voicevox: "VOICEVOX (Local/Free)", openai: "OpenAI TTS", elevenlabs: "ElevenLabs", google: "Google Cloud TTS (Neural2)", gemini: "Gemini TTS (Recommended)" } },
-        { key: "voicevox_host", label: t("settings.config.fields.voicevox_host"), type: "text", showWhen: { key: "pipeline_voice_provider", value: "voicevox" } },
-        { key: "voicevox_speaker_id", label: t("settings.config.fields.voicevox_speaker_id"), type: "number", showWhen: { key: "pipeline_voice_provider", value: "voicevox" } },
-        { key: "openai_tts_model", label: t("settings.config.fields.openai_tts_model"), type: "select", options: ["tts-1", "tts-1-hd"], showWhen: { key: "pipeline_voice_provider", value: "openai" } },
-        { key: "openai_tts_voice", label: t("settings.config.fields.openai_tts_voice"), type: "select", options: ["alloy", "echo", "fable", "onyx", "nova", "shimmer"], showWhen: { key: "pipeline_voice_provider", value: "openai" } },
-        { key: "google_tts_voice", label: t("settings.config.fields.google_tts_voice"), type: "text", showWhen: { key: "pipeline_voice_provider", value: "google" } },
-        { key: "google_tts_language_code", label: t("settings.config.fields.google_tts_language_code"), type: "text", showWhen: { key: "pipeline_voice_provider", value: "google" } },
-        { key: "gemini_tts_model", label: t("settings.config.fields.gemini_tts_model"), type: "select", options: GEMINI_TTS_MODEL_VALUES, optionLabels: GEMINI_TTS_MODEL_LABELS, showWhen: { key: "pipeline_voice_provider", value: "gemini" } },
-        { key: "gemini_tts_voice", label: t("settings.config.fields.gemini_tts_voice"), type: "select", options: GEMINI_TTS_VOICE_VALUES, optionLabels: GEMINI_TTS_VOICE_LABELS, showWhen: { key: "pipeline_voice_provider", value: "gemini" } },
-        { key: "gemini_tts_instructions", label: t("settings.config.fields.gemini_tts_instructions"), type: "text", wide: true, showWhen: { key: "pipeline_voice_provider", value: "gemini" } },
+        { key: "gemini_tts_model", label: t("settings.config.fields.gemini_tts_model"), type: "select", options: GEMINI_TTS_MODEL_VALUES, optionLabels: GEMINI_TTS_MODEL_LABELS },
       ],
     },
     {
@@ -201,6 +193,13 @@ function ConfigSection() {
         { key: "youtube_cta_text", label: t("settings.config.fields.youtube_cta_text"), type: "textarea" },
         { key: "youtube_outro_enabled", label: t("settings.config.fields.youtube_outro_enabled"), type: "checkbox" },
         { key: "youtube_outro_text", label: t("settings.config.fields.youtube_outro_text"), type: "textarea" },
+      ],
+    },
+    {
+      title: t("settings.config.scriptMode"),
+      fields: [
+        { key: "script_default_mode", label: t("settings.config.fields.script_default_mode"), type: "select", options: ["auto", "explainer", "solo"], optionLabels: { auto: "自動（AI推奨）", explainer: "MC＋解説（2人）", solo: "ソロ（1人）" } },
+        { key: "shorts_max_duration_seconds", label: t("settings.config.fields.shorts_max_duration_seconds"), type: "number" },
       ],
     },
     {
@@ -659,6 +658,267 @@ function ConfigSection() {
             {feedback.message}
           </span>
         )}
+      </div>
+    </div>
+  );
+}
+
+function SpeakersSection() {
+  const { t } = useTranslation();
+  const [speakers, setSpeakers] = useState<SpeakerProfile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [form, setForm] = useState({ name: "", role: "anchor", voice_name: "Kore", voice_instructions: "", avatar_position: "right", description: "" });
+  const [adding, setAdding] = useState(false);
+
+  const voiceOptions = GEMINI_TTS_VOICES;
+  const roleOptions = ["anchor", "expert", "narrator"];
+
+  // Role-based recommended presets
+  const rolePresets: Record<string, { voice_name: string; voice_instructions: string; avatar_position: string; description: string }> = {
+    anchor: {
+      voice_name: "Kore",
+      voice_instructions: "落ち着いたニュースキャスターのように、明瞭で聞き取りやすく話してください。テンポよく、信頼感のあるトーンで。",
+      avatar_position: "right",
+      description: "メインMC。番組の進行役として、ニュースの導入や話題の切り替えを担当。",
+    },
+    expert: {
+      voice_name: "Charon",
+      voice_instructions: "知的で分析的なトーンで話してください。専門家として自信を持ちつつも、わかりやすく丁寧に解説する口調で。",
+      avatar_position: "left",
+      description: "解説者。ニュースの背景や複数の視点を深掘りし、専門的な分析を提供。",
+    },
+    narrator: {
+      voice_name: "Aoede",
+      voice_instructions: "自然な語りのトーンで、聞きやすいペースで話してください。感情を込めすぎず、落ち着いたナレーションで。",
+      avatar_position: "right",
+      description: "ソロナレーター。1人でニュースの要点から分析まで通して伝える。",
+    },
+  };
+
+  const fetchSpeakers = useCallback(async () => {
+    try {
+      const res = await api.getSpeakers();
+      setSpeakers(res.data);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchSpeakers(); }, [fetchSpeakers]);
+
+  const resetForm = (role = "anchor") => {
+    const preset = rolePresets[role] ?? rolePresets.anchor;
+    setForm({ name: "", role, ...preset });
+  };
+
+  const handleRoleChange = (newRole: string) => {
+    // When changing role on a new speaker (not editing), apply preset
+    const preset = rolePresets[newRole] ?? rolePresets.anchor;
+    if (editingId) {
+      // Editing existing: only change role, keep other fields
+      setForm((prev) => ({ ...prev, role: newRole }));
+    } else {
+      // New speaker: apply full preset but keep name
+      setForm((prev) => ({ ...prev, role: newRole, ...preset, name: prev.name }));
+    }
+  };
+
+  const handleSave = async () => {
+    if (!form.name.trim()) return;
+    if (editingId) {
+      await api.updateSpeaker(editingId, form);
+    } else {
+      await api.createSpeaker(form);
+    }
+    setEditingId(null);
+    setAdding(false);
+    resetForm();
+    await fetchSpeakers();
+  };
+
+  const handleEdit = (s: SpeakerProfile) => {
+    setEditingId(s.id);
+    setAdding(false);
+    setForm({ name: s.name, role: s.role, voice_name: s.voice_name, voice_instructions: s.voice_instructions, avatar_position: s.avatar_position, description: s.description });
+  };
+
+  const handleDelete = async (id: number) => {
+    await api.deleteSpeaker(id);
+    if (editingId === id) { setEditingId(null); resetForm(); }
+    await fetchSpeakers();
+  };
+
+  const handleAvatarUpload = async (id: number, file: File) => {
+    await api.uploadAvatar(id, file);
+    await fetchSpeakers();
+  };
+
+  const handleAvatarDelete = async (id: number) => {
+    await api.deleteAvatar(id);
+    await fetchSpeakers();
+  };
+
+  if (loading) return <p className="text-gray-500 text-sm">{t("settings.loading")}</p>;
+
+  const renderForm = () => (
+    <div className="bg-gray-50 border rounded-lg p-4 space-y-3">
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">{t("settings.speakers.name")}</label>
+          <input
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            className="px-2 py-1.5 border border-gray-300 rounded text-sm w-full"
+            placeholder="レイナ"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">{t("settings.speakers.role")}</label>
+          <select
+            value={form.role}
+            onChange={(e) => handleRoleChange(e.target.value)}
+            className="px-2 py-1.5 border border-gray-300 rounded text-sm w-full bg-white"
+          >
+            {roleOptions.map((r) => {
+              const taken = speakers.some((s) => s.role === r && s.id !== editingId);
+              return (
+                <option key={r} value={r} disabled={taken}>
+                  {t(`settings.speakers.roles.${r}`)}{taken ? ` (${t("settings.speakers.roleTaken")})` : ""}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">{t("settings.speakers.voiceName")}</label>
+          <select
+            value={form.voice_name}
+            onChange={(e) => setForm({ ...form, voice_name: e.target.value })}
+            className="px-2 py-1.5 border border-gray-300 rounded text-sm w-full bg-white"
+          >
+            {voiceOptions.map((v) => (
+              <option key={v.value} value={v.value}>{v.label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">{t("settings.speakers.avatarPosition")}</label>
+          <select
+            value={form.avatar_position}
+            onChange={(e) => setForm({ ...form, avatar_position: e.target.value })}
+            className="px-2 py-1.5 border border-gray-300 rounded text-sm w-full bg-white"
+          >
+            <option value="left">Left</option>
+            <option value="right">Right</option>
+          </select>
+        </div>
+      </div>
+      <div>
+        <label className="block text-xs text-gray-500 mb-1">{t("settings.speakers.voiceInstructions")}</label>
+        <input
+          value={form.voice_instructions}
+          onChange={(e) => setForm({ ...form, voice_instructions: e.target.value })}
+          className="px-2 py-1.5 border border-gray-300 rounded text-sm w-full"
+          placeholder="落ち着いたニュースキャスターのように話してください"
+        />
+      </div>
+      <div>
+        <label className="block text-xs text-gray-500 mb-1">{t("settings.speakers.description")}</label>
+        <input
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+          className="px-2 py-1.5 border border-gray-300 rounded text-sm w-full"
+          placeholder="メインMC。冷静で分析的な進行役。"
+        />
+      </div>
+      <div className="flex gap-2">
+        <button onClick={handleSave} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 cursor-pointer">
+          {t("settings.speakers.save")}
+        </button>
+        <button onClick={() => { setEditingId(null); setAdding(false); resetForm(); }} className="px-3 py-1.5 text-gray-600 border rounded text-sm hover:bg-gray-50 cursor-pointer">
+          {t("settings.speakers.cancel")}
+        </button>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-medium text-gray-800">{t("settings.speakers.title")}</h3>
+        {!adding && !editingId && (
+          <button onClick={() => {
+            const takenRoles = new Set(speakers.map((s) => s.role));
+            const availableRole = roleOptions.find((r) => !takenRoles.has(r)) ?? "anchor";
+            setAdding(true);
+            resetForm(availableRole);
+          }} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 cursor-pointer"
+            disabled={speakers.length >= roleOptions.length}>
+            {t("settings.speakers.add")}
+          </button>
+        )}
+      </div>
+
+      {adding && renderForm()}
+
+      {speakers.length === 0 && !adding && (
+        <p className="text-sm text-gray-500">{t("settings.speakers.empty")}</p>
+      )}
+
+      <div className="space-y-3">
+        {speakers.map((s) => (
+          <div key={s.id} className="border rounded-lg p-4">
+            {editingId === s.id ? renderForm() : (
+              <div className="flex items-start justify-between">
+                <div className="flex items-start gap-3">
+                  {s.avatar_path && (
+                    <img src={`/media/avatars/speaker_${s.id}.png`} alt={s.name} className="w-12 h-12 rounded-full object-cover" />
+                  )}
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-gray-800">{s.name}</span>
+                      <span className="px-2 py-0.5 rounded-full text-xs bg-gray-100 text-gray-600">
+                        {t(`settings.speakers.roles.${s.role}`, s.role)}
+                      </span>
+                      <span className="text-xs text-gray-400">
+                        {GEMINI_TTS_VOICES.find((v) => v.value === s.voice_name)?.label ?? s.voice_name}
+                      </span>
+                    </div>
+                    {s.description && <p className="text-sm text-gray-500 mt-1">{s.description}</p>}
+                    {s.voice_instructions && <p className="text-xs text-gray-400 mt-1">{s.voice_instructions}</p>}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <label className="text-xs text-blue-600 hover:underline cursor-pointer">
+                    {t("settings.speakers.uploadAvatar")}
+                    <input
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) handleAvatarUpload(s.id, file);
+                        e.target.value = "";
+                      }}
+                    />
+                  </label>
+                  {s.avatar_path && (
+                    <button onClick={() => handleAvatarDelete(s.id)} className="text-xs text-red-500 hover:underline cursor-pointer">
+                      {t("settings.speakers.removeAvatar")}
+                    </button>
+                  )}
+                  <button onClick={() => handleEdit(s)} className="text-xs text-blue-600 hover:underline cursor-pointer">
+                    {t("settings.speakers.edit")}
+                  </button>
+                  <button onClick={() => handleDelete(s.id)} className="text-xs text-red-500 hover:underline cursor-pointer">
+                    {t("settings.speakers.delete")}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/components/step-renderers/AnalysisRenderer.tsx
+++ b/frontend/src/components/step-renderers/AnalysisRenderer.tsx
@@ -76,6 +76,28 @@ function AnalysisDetail({ data }: { data: AnalysisData }) {
           <p className="text-gray-700">{data.impact}</p>
         </div>
       )}
+
+      {data.recommended_format && (
+        <div>
+          <p className="text-xs font-medium text-gray-500 mb-1">
+            {t("stepData.analysis.recommendedFormat")}
+          </p>
+          <div className="flex items-center gap-2">
+            <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+              data.recommended_format === "explainer"
+                ? "bg-indigo-100 text-indigo-700"
+                : "bg-gray-100 text-gray-700"
+            }`}>
+              {data.recommended_format === "explainer"
+                ? t("stepData.analysis.formatExplainer")
+                : t("stepData.analysis.formatSolo")}
+            </span>
+            {data.format_reason && (
+              <span className="text-xs text-gray-500">{data.format_reason}</span>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -149,6 +171,17 @@ export default function AnalysisRenderer({ newsItems }: Props) {
             {isMerged && (
               <span className="px-2 py-0.5 rounded-full text-xs bg-gray-100 text-gray-500">
                 {t("stepData.analysis.merged")}
+              </span>
+            )}
+            {!isMerged && data?.recommended_format && (
+              <span className={`px-2 py-0.5 rounded-full text-xs ${
+                data.recommended_format === "explainer"
+                  ? "bg-indigo-50 text-indigo-600"
+                  : "bg-gray-50 text-gray-600"
+              }`}>
+                {data.recommended_format === "explainer"
+                  ? t("stepData.analysis.formatExplainer")
+                  : t("stepData.analysis.formatSolo")}
               </span>
             )}
             {!isMerged && data?.severity && (

--- a/frontend/src/constants/tts.ts
+++ b/frontend/src/constants/tts.ts
@@ -21,12 +21,8 @@ export const GEMINI_TTS_VOICES = [
 
 /** Helper: extract value arrays for Settings select fields. */
 export const GEMINI_TTS_MODEL_VALUES = GEMINI_TTS_MODELS.map((m) => m.value);
-export const GEMINI_TTS_VOICE_VALUES = GEMINI_TTS_VOICES.map((v) => v.value);
 
 /** Helper: build { value: label } maps for Settings optionLabels. */
 export const GEMINI_TTS_MODEL_LABELS = Object.fromEntries(
   GEMINI_TTS_MODELS.map((m) => [m.value, m.label]),
-);
-export const GEMINI_TTS_VOICE_LABELS = Object.fromEntries(
-  GEMINI_TTS_VOICES.map((v) => [v.value, v.label]),
 );

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -167,7 +167,10 @@
       "merged": "Merged",
       "group": "Group",
       "sources": "sources",
-      "groupCount": "{{count}} group(s) detected"
+      "groupCount": "{{count}} group(s) detected",
+      "recommendedFormat": "Recommended Format",
+      "formatExplainer": "MC + Expert (2 speakers)",
+      "formatSolo": "Solo (1 speaker)"
     },
     "script": {
       "fullScript": "Full Episode Script",
@@ -203,6 +206,7 @@
       "soundEffects": "Sound Effects",
       "visual": "Visual",
       "youtube": "YouTube Settings",
+      "scriptMode": "Script Mode",
       "googleDrive": "Google Drive Export",
       "fields": {
         "default_ai_provider": "Default AI Provider",
@@ -228,16 +232,7 @@
         "collection_ai_research_enabled": "AI Research Enabled",
         "voice_section_silence": "Section Silence (seconds)",
         "srt_offset": "Subtitle Offset (sec, + = later)",
-        "pipeline_voice_provider": "Voice Provider",
-        "voicevox_host": "VOICEVOX Host",
-        "voicevox_speaker_id": "VOICEVOX Speaker ID",
-        "openai_tts_model": "OpenAI TTS Model",
-        "openai_tts_voice": "OpenAI TTS Voice",
-        "google_tts_voice": "Google TTS Voice",
-        "google_tts_language_code": "Google TTS Language",
         "gemini_tts_model": "Gemini TTS Model",
-        "gemini_tts_voice": "Gemini TTS Voice",
-        "gemini_tts_instructions": "Gemini TTS Instructions",
         "se_intro": "Intro SE (before opening)",
         "se_transition": "Transition SE (between news)",
         "se_outro": "Outro SE (after ending)",
@@ -257,7 +252,9 @@
         "google_drive_enabled": "Enabled",
         "google_drive_client_id": "OAuth Client ID",
         "google_drive_client_secret": "OAuth Client Secret",
-        "google_drive_folder_id": "Google Drive Folder ID"
+        "google_drive_folder_id": "Google Drive Folder ID",
+        "script_default_mode": "Default Script Mode",
+        "shorts_max_duration_seconds": "Shorts Max Duration (sec)"
       },
       "sePreview": "Preview",
       "seDownload": "DL",
@@ -308,6 +305,29 @@
       "save": "Save",
       "delete": "Delete",
       "empty": "No dictionary entries. Click \"Add\" to register pronunciations."
+    },
+    "speakers": {
+      "title": "Speaker Profiles",
+      "add": "Add",
+      "name": "Name",
+      "role": "Role",
+      "voiceName": "Voice",
+      "voiceInstructions": "Voice Instructions",
+      "avatarPosition": "Avatar Position",
+      "description": "Description",
+      "save": "Save",
+      "delete": "Delete",
+      "edit": "Edit",
+      "cancel": "Cancel",
+      "empty": "No speakers registered. Click \"Add\" to create one.",
+      "roles": {
+        "anchor": "Anchor (MC)",
+        "expert": "Expert",
+        "narrator": "Narrator"
+      },
+      "uploadAvatar": "Avatar Image",
+      "removeAvatar": "Remove",
+      "roleTaken": "taken"
     },
     "prompts": {
       "title": "Prompt Templates",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -167,7 +167,10 @@
       "merged": "統合済",
       "group": "グループ",
       "sources": "ソース",
-      "groupCount": "{{count}}件のグループが検出されました"
+      "groupCount": "{{count}}件のグループが検出されました",
+      "recommendedFormat": "推奨フォーマット",
+      "formatExplainer": "MC＋解説（2人）",
+      "formatSolo": "ソロ（1人）"
     },
     "script": {
       "fullScript": "エピソード全体台本",
@@ -203,6 +206,7 @@
       "soundEffects": "効果音",
       "visual": "ビジュアル",
       "youtube": "YouTube 設定",
+      "scriptMode": "台本モード",
       "googleDrive": "Google Drive エクスポート",
       "fields": {
         "default_ai_provider": "デフォルト AI プロバイダー",
@@ -228,16 +232,7 @@
         "collection_ai_research_enabled": "AI リサーチ有効",
         "voice_section_silence": "セクション間の無音（秒）",
         "srt_offset": "字幕オフセット（秒、+で遅延）",
-        "pipeline_voice_provider": "音声プロバイダー",
-        "voicevox_host": "VOICEVOX ホスト",
-        "voicevox_speaker_id": "VOICEVOX スピーカー ID",
-        "openai_tts_model": "OpenAI TTS モデル",
-        "openai_tts_voice": "OpenAI TTS ボイス",
-        "google_tts_voice": "Google TTS ボイス",
-        "google_tts_language_code": "Google TTS 言語",
         "gemini_tts_model": "Gemini TTS モデル",
-        "gemini_tts_voice": "Gemini TTS ボイス",
-        "gemini_tts_instructions": "Gemini TTS 話し方指示",
         "se_intro": "イントロ効果音（オープニング前）",
         "se_transition": "トランジション効果音（ニュース間）",
         "se_outro": "アウトロ効果音（エンディング後）",
@@ -257,7 +252,9 @@
         "google_drive_enabled": "有効",
         "google_drive_client_id": "OAuth クライアント ID",
         "google_drive_client_secret": "OAuth クライアント シークレット",
-        "google_drive_folder_id": "Google Drive フォルダ ID"
+        "google_drive_folder_id": "Google Drive フォルダ ID",
+        "script_default_mode": "台本デフォルトモード",
+        "shorts_max_duration_seconds": "ショート最大秒数"
       },
       "sePreview": "試聴",
       "seDownload": "DL",
@@ -308,6 +305,29 @@
       "save": "保存",
       "delete": "削除",
       "empty": "辞書エントリがありません。「追加」ボタンで読みを登録してください。"
+    },
+    "speakers": {
+      "title": "スピーカー管理",
+      "add": "追加",
+      "name": "名前",
+      "role": "役割",
+      "voiceName": "ボイス",
+      "voiceInstructions": "話し方指示",
+      "avatarPosition": "アバター位置",
+      "description": "説明",
+      "save": "保存",
+      "delete": "削除",
+      "edit": "編集",
+      "cancel": "キャンセル",
+      "empty": "スピーカーが登録されていません。「追加」ボタンで作成してください。",
+      "roles": {
+        "anchor": "MC（進行）",
+        "expert": "解説者",
+        "narrator": "ナレーター"
+      },
+      "uploadAvatar": "アバター画像",
+      "removeAvatar": "削除",
+      "roleTaken": "設定済"
     },
     "prompts": {
       "title": "プロンプトテンプレート",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -56,6 +56,8 @@ export interface NewsItem {
   reference_urls: string[] | null;
   analysis_data: Record<string, unknown> | null;
   script_text: string | null;
+  script_mode: string | null;
+  script_data: Record<string, unknown> | null;
   group_id: number | null;
   is_group_primary: boolean | null;
   excluded: boolean;
@@ -73,6 +75,8 @@ export interface AnalysisData {
   source_comparison?: string;
   severity?: string;
   topics?: string[];
+  recommended_format?: "explainer" | "solo";
+  format_reason?: string;
 }
 
 export interface EpisodeListResponse {
@@ -169,6 +173,19 @@ export interface DriveExportResponse {
   source_text_length: number;
   input_tokens: number;
   output_tokens: number;
+}
+
+export interface SpeakerProfile {
+  id: number;
+  name: string;
+  role: string;
+  voice_name: string;
+  voice_instructions: string;
+  avatar_path: string | null;
+  avatar_position: string;
+  description: string;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface AppSettings {


### PR DESCRIPTION
## Summary

マルチスピーカー + ショート + アバター統合 (#85) の Phase 1。全フェーズの土台を構築。

- **speaker_profiles テーブル**: ロール別（anchor/expert/narrator）にユニーク制約、デフォルト3人シード
- **スピーカー CRUD API**: GET/POST/PUT/DELETE + アバターアップロード/削除
- **DB拡張**: news_items に `script_mode` / `script_data`、episodes に `shorts_enabled`
- **分析ステップ**: プロンプトに `recommended_format` / `format_reason` 追加（explainer/solo 推奨）
- **音声設定リファクタ**: Gemini TTS に統一、ボイス・話し方指示をスピーカー管理に移行
- **scriptwriter**: TTS 指示をスピーカープロファイルから取得
- **フロントエンド**: スピーカー管理タブ、推奨フォーマットバッジ、台本モード設定

Closes #103

## Test plan

- [ ] マイグレーション実行/ロールバック確認
- [ ] スピーカー CRUD（作成・編集・削除・ロール重複拒否）
- [ ] 分析実行 → `recommended_format` 出力確認
- [ ] 既存パイプライン（ソロ）が壊れないこと
- [ ] 設定画面のスピーカー管理タブ表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)