### PR TITLE
refactor: UIからElevenLabs APIキー設定を削除

### DIFF
--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -146,7 +146,6 @@ function ConfigSection() {
         { key: "openai_api_key", label: t("settings.config.fields.openai_api_key"), type: "password" },
         { key: "google_api_key", label: t("settings.config.fields.google_api_key"), type: "password" },
         { key: "brave_search_api_key", label: t("settings.config.fields.brave_search_api_key"), type: "password" },
-        { key: "elevenlabs_api_key", label: t("settings.config.fields.elevenlabs_api_key"), type: "password" },
       ],
     },
     {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -232,7 +232,6 @@
         "openai_api_key": "OpenAI API Key",
         "google_api_key": "Google API Key",
         "brave_search_api_key": "Brave Search API Key",
-        "elevenlabs_api_key": "ElevenLabs API Key",
         "collection_method": "Collection Method",
         "collection_queries": "Collection Queries",
         "collection_crawl_enabled": "Crawl Enabled",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -232,7 +232,6 @@
         "openai_api_key": "OpenAI API キー",
         "google_api_key": "Google API キー",
         "brave_search_api_key": "Brave Search API キー",
-        "elevenlabs_api_key": "ElevenLabs API キー",
         "collection_method": "収集方法",
         "collection_queries": "検索クエリ",
         "collection_crawl_enabled": "クロール有効",


### PR DESCRIPTION
## Summary

Gemini TTS 統一に伴い、使用されない ElevenLabs API キーを UI 設定欄から削除。

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)