### PR TITLE
feat: note.com マークダウン記事生成 + カバー画像生成

### DIFF
--- a/backend/alembic/versions/018_add_note_article_columns.py
+++ b/backend/alembic/versions/018_add_note_article_columns.py
@@ -1,0 +1,25 @@
+"""Add note_analysis_article, note_video_article to episodes
+
+Revision ID: 018
+Revises: 017
+Create Date: 2026-03-18
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "018"
+down_revision = "017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("episodes", sa.Column("note_analysis_article", sa.Text(), nullable=True))
+    op.add_column("episodes", sa.Column("note_video_article", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("episodes", "note_video_article")
+    op.drop_column("episodes", "note_analysis_article")

--- a/backend/app/api/episodes.py
+++ b/backend/app/api/episodes.py
@@ -15,13 +15,15 @@ from app.api.schemas import (
     EpisodeListResponse,
     EpisodeResponse,
     NewsItemResponse,
+    NoteArticleResponse,
 )
 from app.config import settings
 from app.database import get_session
-from app.services.export_source_text import generate_source_text
-from app.services.google_drive import GoogleDriveService
 from app.models import Episode, EpisodeStatus, NewsItem, StepStatus
 from app.pipeline import engine
+from app.services.export_source_text import generate_source_text
+from app.services.google_drive import GoogleDriveService
+from app.services.note_article import generate_note_analysis, generate_note_cover_image, generate_note_video
 
 router = APIRouter(tags=["episodes"])
 
@@ -84,9 +86,7 @@ async def update_episode(
     session: AsyncSession = Depends(get_session),
 ) -> Episode:
     """Update episode fields (currently only title)."""
-    result = await session.execute(
-        select(Episode).where(Episode.id == episode_id)
-    )
+    result = await session.execute(select(Episode).where(Episode.id == episode_id))
     episode = result.scalar_one_or_none()
     if not episode:
         raise HTTPException(status_code=404, detail="Episode not found")
@@ -137,11 +137,7 @@ async def get_news_items(
     session: AsyncSession = Depends(get_session),
 ) -> list[NewsItem]:
     """Get all news items for an episode."""
-    result = await session.execute(
-        select(NewsItem)
-        .where(NewsItem.episode_id == episode_id)
-        .order_by(NewsItem.id)
-    )
+    result = await session.execute(select(NewsItem).where(NewsItem.episode_id == episode_id).order_by(NewsItem.id))
     return list(result.scalars().all())
 
 
@@ -183,7 +179,9 @@ async def export_to_drive(
     if not settings.google_drive_enabled:
         raise HTTPException(status_code=400, detail="Google Drive export is not enabled")
     if not settings.google_drive_refresh_token:
-        raise HTTPException(status_code=400, detail="Google Drive is not authenticated. Please authenticate via Settings.")
+        raise HTTPException(
+            status_code=400, detail="Google Drive is not authenticated. Please authenticate via Settings."
+        )
 
     # Load episode with relationships
     result = await session.execute(
@@ -239,3 +237,139 @@ async def export_to_drive(
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
     }
+
+
+# --- note.com article endpoints ---
+
+
+async def _get_episode_and_items(episode_id: int, session: AsyncSession) -> tuple[Episode, list[NewsItem]]:
+    """Load episode with pipeline steps and non-excluded news items."""
+    result = await session.execute(
+        select(Episode).where(Episode.id == episode_id).options(selectinload(Episode.pipeline_steps))
+    )
+    episode = result.scalar_one_or_none()
+    if not episode:
+        raise HTTPException(status_code=404, detail="Episode not found")
+
+    items_result = await session.execute(
+        select(NewsItem).where(NewsItem.episode_id == episode_id, NewsItem.excluded.is_(False)).order_by(NewsItem.id)
+    )
+    news_items = list(items_result.scalars().all())
+    if not news_items:
+        raise HTTPException(status_code=400, detail="No news items available")
+
+    return episode, news_items
+
+
+@router.post("/episodes/{episode_id}/note/analysis", response_model=NoteArticleResponse)
+async def generate_note_analysis_article(
+    episode_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> NoteArticleResponse:
+    """Generate a note.com analysis article from episode analysis data."""
+    episode, news_items = await _get_episode_and_items(episode_id, session)
+
+    analysis_step = next((s for s in episode.pipeline_steps if s.step_name.value == "analysis"), None)
+    if not analysis_step or analysis_step.status.value != "approved":
+        raise HTTPException(status_code=400, detail="Analysis step must be approved before generating")
+
+    markdown, input_tokens, output_tokens = await generate_note_analysis(episode, news_items, session)
+
+    episode.note_analysis_article = markdown
+    await session.commit()
+
+    return NoteArticleResponse(
+        episode_id=episode_id,
+        article_type="analysis",
+        markdown=markdown,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+@router.get("/episodes/{episode_id}/note/analysis", response_model=NoteArticleResponse)
+async def get_note_analysis_article(
+    episode_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> NoteArticleResponse:
+    """Get the saved note.com analysis article."""
+    result = await session.execute(select(Episode).where(Episode.id == episode_id))
+    episode = result.scalar_one_or_none()
+    if not episode:
+        raise HTTPException(status_code=404, detail="Episode not found")
+    if not episode.note_analysis_article:
+        raise HTTPException(status_code=404, detail="Analysis article not yet generated")
+
+    return NoteArticleResponse(
+        episode_id=episode_id,
+        article_type="analysis",
+        markdown=episode.note_analysis_article,
+        input_tokens=0,
+        output_tokens=0,
+    )
+
+
+@router.post("/episodes/{episode_id}/note/video", response_model=NoteArticleResponse)
+async def generate_note_video_article(
+    episode_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> NoteArticleResponse:
+    """Generate a note.com video introduction article."""
+    episode, news_items = await _get_episode_and_items(episode_id, session)
+
+    video_step = next((s for s in episode.pipeline_steps if s.step_name.value == "video"), None)
+    if not video_step or video_step.status.value not in ("needs_approval", "approved"):
+        raise HTTPException(status_code=400, detail="Video step must be completed before generating")
+
+    video_output = video_step.output_data if video_step else None
+    markdown, input_tokens, output_tokens = await generate_note_video(episode, news_items, video_output, session)
+
+    episode.note_video_article = markdown
+    await session.commit()
+
+    return NoteArticleResponse(
+        episode_id=episode_id,
+        article_type="video",
+        markdown=markdown,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+@router.get("/episodes/{episode_id}/note/video", response_model=NoteArticleResponse)
+async def get_note_video_article(
+    episode_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> NoteArticleResponse:
+    """Get the saved note.com video article."""
+    result = await session.execute(select(Episode).where(Episode.id == episode_id))
+    episode = result.scalar_one_or_none()
+    if not episode:
+        raise HTTPException(status_code=404, detail="Episode not found")
+    if not episode.note_video_article:
+        raise HTTPException(status_code=404, detail="Video article not yet generated")
+
+    return NoteArticleResponse(
+        episode_id=episode_id,
+        article_type="video",
+        markdown=episode.note_video_article,
+        input_tokens=0,
+        output_tokens=0,
+    )
+
+
+@router.post("/episodes/{episode_id}/note/{article_type}/cover")
+async def generate_note_cover(
+    episode_id: int,
+    article_type: str,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Generate a cover image for a note.com article."""
+    if article_type not in ("analysis", "video"):
+        raise HTTPException(status_code=400, detail="article_type must be 'analysis' or 'video'")
+
+    episode, news_items = await _get_episode_and_items(episode_id, session)
+
+    image_path = await generate_note_cover_image(episode, news_items, article_type, session)
+
+    return {"episode_id": episode_id, "article_type": article_type, "image_path": image_path}

--- a/backend/app/api/prompts.py
+++ b/backend/app/api/prompts.py
@@ -14,6 +14,7 @@ import app.pipeline.factchecker  # noqa: F401
 import app.pipeline.scriptwriter  # noqa: F401
 import app.pipeline.video  # noqa: F401
 import app.services.export_source_text  # noqa: F401
+import app.services.note_article  # noqa: F401
 from app.database import get_session
 from app.models.prompt_template import PromptTemplate
 from app.services.prompt_loader import get_all_defaults
@@ -30,6 +31,8 @@ PROMPT_NAMES: dict[str, str] = {
     "youtube_metadata": "YouTube メタデータ",
     "export_notebooklm": "NotebookLM エクスポート",
     "export_notebooklm_instructions": "NotebookLM AIホスト指示",
+    "note_analysis_article": "note.com 分析記事",
+    "note_video_article": "note.com 動画紹介記事",
 }
 
 
@@ -84,7 +87,9 @@ async def list_prompts(session: AsyncSession = Depends(get_session)):
 
     # Get all active templates
     result = await session.execute(
-        select(PromptTemplate).where(PromptTemplate.is_active == True).order_by(  # noqa: E712
+        select(PromptTemplate)
+        .where(PromptTemplate.is_active == True)  # noqa: E712
+        .order_by(
             PromptTemplate.key
         )
     )
@@ -144,16 +149,12 @@ async def update_prompt(key: str, body: PromptUpdateRequest, session: AsyncSessi
 
     # Get current max version
     result = await session.execute(
-        select(PromptTemplate.version).where(PromptTemplate.key == key).order_by(
-            PromptTemplate.version.desc()
-        ).limit(1)
+        select(PromptTemplate.version).where(PromptTemplate.key == key).order_by(PromptTemplate.version.desc()).limit(1)
     )
     max_version = result.scalar_one_or_none() or 0
 
     # Deactivate all existing versions for this key
-    await session.execute(
-        update(PromptTemplate).where(PromptTemplate.key == key).values(is_active=False)
-    )
+    await session.execute(update(PromptTemplate).where(PromptTemplate.key == key).values(is_active=False))
 
     # Create new version
     new_template = PromptTemplate(
@@ -185,9 +186,7 @@ async def rollback_prompt(key: str, version: int, session: AsyncSession = Depend
         raise HTTPException(status_code=404, detail=f"Version {version} not found for key: {key}")
 
     # Deactivate all versions
-    await session.execute(
-        update(PromptTemplate).where(PromptTemplate.key == key).values(is_active=False)
-    )
+    await session.execute(update(PromptTemplate).where(PromptTemplate.key == key).values(is_active=False))
 
     # Activate the target version
     target.is_active = True
@@ -204,7 +203,5 @@ async def reset_prompt(key: str, session: AsyncSession = Depends(get_session)):
     if key not in PROMPT_NAMES:
         raise HTTPException(status_code=404, detail=f"Unknown prompt key: {key}")
 
-    await session.execute(
-        update(PromptTemplate).where(PromptTemplate.key == key).values(is_active=False)
-    )
+    await session.execute(update(PromptTemplate).where(PromptTemplate.key == key).values(is_active=False))
     await session.commit()

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -105,6 +105,8 @@ class EpisodeResponse(BaseModel):
     drive_file_id: str | None = None
     drive_file_url: str | None = None
     shorts_enabled: bool = False
+    note_analysis_article: str | None = None
+    note_video_article: str | None = None
     pipeline_steps: list[StepResponse] = []
 
     model_config = {"from_attributes": True}
@@ -155,6 +157,16 @@ class NewsItemResponse(BaseModel):
             if len(self.body) > _BODY_TRUNCATE_CHARS:
                 self.body = self.body[:_BODY_TRUNCATE_CHARS] + "…"
         return self
+
+
+class NoteArticleResponse(BaseModel):
+    """Response for a generated note.com article."""
+
+    episode_id: int
+    article_type: str
+    markdown: str
+    input_tokens: int
+    output_tokens: int
 
 
 class PronunciationResponse(BaseModel):

--- a/backend/app/models/episode.py
+++ b/backend/app/models/episode.py
@@ -1,7 +1,7 @@
 import enum
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Enum, String, func
+from sqlalchemy import Boolean, DateTime, Enum, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
@@ -29,6 +29,8 @@ class Episode(Base):
     drive_file_id: Mapped[str | None] = mapped_column(String(200), nullable=True)
     drive_file_url: Mapped[str | None] = mapped_column(String(2000), nullable=True)
     shorts_enabled: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+    note_analysis_article: Mapped[str | None] = mapped_column(Text, nullable=True)
+    note_video_article: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     news_items: Mapped[list["NewsItem"]] = relationship(back_populates="episode", cascade="all, delete-orphan")
     pipeline_steps: Mapped[list["PipelineStep"]] = relationship(back_populates="episode", cascade="all, delete-orphan")

--- a/backend/app/services/note_article.py
+++ b/backend/app/services/note_article.py
@@ -1,0 +1,274 @@
+"""Generate note.com markdown articles and cover images from episode data."""
+
+import logging
+import os
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.models import ApiUsage, Episode, NewsItem
+from app.services.ai_provider import AIResponse, get_provider
+from app.services.cost_estimator import estimate_cost
+from app.services.prompt_loader import get_active_prompt, register_default
+from app.services.visual_provider import get_visual_provider
+
+logger = logging.getLogger(__name__)
+
+# --- Analysis article prompt ---
+
+ANALYSIS_PROMPT_KEY = "note_analysis_article"
+
+ANALYSIS_SYSTEM_PROMPT = """\
+あなたはニュース分析結果を、note.comに投稿するマークダウン記事に変換する専門ライターです。
+
+## 記事構成
+1. **タイトル**（H1）: 読者の関心を引く、具体的でわかりやすいタイトル
+2. **リード文**: 3行以内で記事の要点
+3. **各ニュースの解説**: 背景・クリティカル分析・生活への影響
+4. **まとめ**: 全体を俯瞰した考察と読者への問いかけ
+5. **ソース一覧**: 参照元リンク
+
+## 文体
+- 「です・ます」調
+- 専門用語はその場で言い換え
+- 断定を避け、複数の視点を公平に提示
+- 1段落3-4行以内
+
+## note.com最適化
+- 見出し（##）を効果的に使用
+- 引用（>）で重要ポイント強調
+- 箇条書きで複数視点を整理"""
+
+register_default(ANALYSIS_PROMPT_KEY, ANALYSIS_SYSTEM_PROMPT)
+
+# --- Video article prompt ---
+
+VIDEO_PROMPT_KEY = "note_video_article"
+
+VIDEO_SYSTEM_PROMPT = """\
+あなたはYouTube動画の紹介記事を、note.comに投稿するマークダウン記事に変換する専門ライターです。
+
+## 記事構成
+1. **タイトル**（H1）: 動画内容を反映した魅力的なタイトル
+2. **動画リンク**: YouTube URLプレースホルダー
+3. **概要**: 動画で取り上げた話題の要約
+4. **ハイライト**: 見どころを箇条書き
+5. **各ニュースの要点**: ニュースごとの簡潔なまとめ
+6. **おわりに**: チャンネル登録の案内
+
+## 文体
+- 「です・ます」調
+- カジュアルすぎず堅すぎないトーン
+- 動画を見たくなる期待感
+
+## note.com最適化
+- 見出し（##）を効果的に使用
+- YouTube URL は {{YOUTUBE_URL}} プレースホルダー"""
+
+register_default(VIDEO_PROMPT_KEY, VIDEO_SYSTEM_PROMPT)
+
+
+def _build_items_text(news_items: list[NewsItem]) -> str:
+    """Build text representation of news items for AI prompt."""
+    items_text = ""
+    for i, item in enumerate(news_items):
+        items_text += f"\n## ニュース {i + 1}: {item.title}\n"
+        items_text += f"ソース: {item.source_name} ({item.source_url})\n"
+        if item.summary:
+            items_text += f"要約: {item.summary}\n"
+        if item.fact_check_score is not None:
+            items_text += f"ファクトチェックスコア: {item.fact_check_score}/5\n"
+        if item.fact_check_details:
+            items_text += f"ファクトチェック詳細: {item.fact_check_details}\n"
+        if item.analysis_data:
+            ad = item.analysis_data
+            if ad.get("background"):
+                items_text += f"背景: {ad['background']}\n"
+            if ad.get("why_now"):
+                items_text += f"なぜ今: {ad['why_now']}\n"
+            if ad.get("perspectives"):
+                items_text += "視点:\n"
+                for p in ad["perspectives"]:
+                    items_text += (
+                        f"  - {p.get('standpoint', '不明')}: {p.get('argument', '')} (根拠: {p.get('basis', '')})\n"
+                    )
+            if ad.get("data_validation"):
+                items_text += f"データ検証: {ad['data_validation']}\n"
+            if ad.get("impact"):
+                items_text += f"影響評価: {ad['impact']}\n"
+            if ad.get("uncertainties"):
+                items_text += f"不確実性: {ad['uncertainties']}\n"
+            if ad.get("source_comparison"):
+                items_text += f"ソース比較: {ad['source_comparison']}\n"
+        items_text += "\n"
+    return items_text
+
+
+async def _record_usage(
+    session: AsyncSession,
+    episode: Episode,
+    response: AIResponse,
+) -> None:
+    """Record API usage for note export."""
+    cost = await estimate_cost(session, response.model, response.input_tokens, response.output_tokens)
+    session.add(
+        ApiUsage(
+            episode_id=episode.id,
+            step_name="note_export",
+            provider=response.provider,
+            model=response.model,
+            input_tokens=response.input_tokens,
+            output_tokens=response.output_tokens,
+            cost_usd=cost,
+        )
+    )
+    await session.commit()
+
+
+async def generate_note_analysis(
+    episode: Episode,
+    news_items: list[NewsItem],
+    session: AsyncSession,
+) -> tuple[str, int, int]:
+    """Generate a note.com analysis article from episode analysis data.
+
+    Returns:
+        Tuple of (markdown, input_tokens, output_tokens).
+    """
+    provider_name = settings.pipeline_export_provider or settings.default_ai_provider
+    model = settings.pipeline_export_model or settings.default_ai_model
+    provider = get_provider(provider_name)
+
+    system_prompt, _ = await get_active_prompt(session, ANALYSIS_PROMPT_KEY)
+
+    items_text = _build_items_text(news_items)
+    user_prompt = (
+        f"# エピソード: {episode.title}\n\n"
+        f"以下の{len(news_items)}件のニュース分析結果を、"
+        f"note.com用のマークダウン記事に変換してください。\n"
+        f"{items_text}"
+    )
+
+    response: AIResponse = await provider.generate(
+        prompt=user_prompt,
+        model=model,
+        system=system_prompt,
+    )
+
+    await _record_usage(session, episode, response)
+    return response.content, response.input_tokens, response.output_tokens
+
+
+async def generate_note_video(
+    episode: Episode,
+    news_items: list[NewsItem],
+    video_output: dict | None,
+    session: AsyncSession,
+) -> tuple[str, int, int]:
+    """Generate a note.com video introduction article.
+
+    Returns:
+        Tuple of (markdown, input_tokens, output_tokens).
+    """
+    provider_name = settings.pipeline_export_provider or settings.default_ai_provider
+    model = settings.pipeline_export_model or settings.default_ai_model
+    provider = get_provider(provider_name)
+
+    system_prompt, _ = await get_active_prompt(session, VIDEO_PROMPT_KEY)
+
+    items_text = _build_items_text(news_items)
+
+    # Add video metadata if available
+    video_info = ""
+    if video_output:
+        yt_meta = video_output.get("youtube_metadata", {})
+        if yt_meta:
+            if yt_meta.get("title"):
+                video_info += f"動画タイトル: {yt_meta['title']}\n"
+            if yt_meta.get("description"):
+                video_info += f"動画概要: {yt_meta['description']}\n"
+            if yt_meta.get("tags"):
+                video_info += f"タグ: {', '.join(yt_meta['tags'])}\n"
+
+    user_prompt = f"# エピソード: {episode.title}\n\n"
+    if video_info:
+        user_prompt += f"## 動画メタデータ\n{video_info}\n"
+    user_prompt += (
+        f"以下の{len(news_items)}件のニュースを取り上げたYouTube動画の紹介記事を、"
+        f"note.com用のマークダウンで作成してください。\n"
+        f"{items_text}"
+    )
+
+    response: AIResponse = await provider.generate(
+        prompt=user_prompt,
+        model=model,
+        system=system_prompt,
+    )
+
+    await _record_usage(session, episode, response)
+    return response.content, response.input_tokens, response.output_tokens
+
+
+async def generate_note_cover_image(
+    episode: Episode,
+    news_items: list[NewsItem],
+    article_type: str,
+    session: AsyncSession,
+) -> str:
+    """Generate a cover image for a note.com article using AI prompt + Imagen.
+
+    Returns:
+        Relative media path to the generated image.
+    """
+    provider_name = settings.pipeline_export_provider or settings.default_ai_provider
+    model = settings.pipeline_export_model or settings.default_ai_model
+    ai_provider = get_provider(provider_name)
+
+    topics = ", ".join(item.title for item in news_items[:5])
+    prompt_request = (
+        f"Generate a short (1-2 sentences) image prompt in English for an Imagen 4 model.\n"
+        f"The image is a cover/header for a note.com article about: {episode.title}\n"
+        f"Topics covered: {topics}\n"
+        f"Requirements:\n"
+        f"- Abstract, editorial-style illustration\n"
+        f"- No text, no letters, no words, no watermarks\n"
+        f"- Suitable for a news analysis blog post\n"
+        f"- Visually appealing, professional\n"
+        f"Return ONLY the image prompt, nothing else."
+    )
+
+    response: AIResponse = await ai_provider.generate(
+        prompt=prompt_request,
+        model=model,
+        system="You are an image prompt generator. Return only the image generation prompt.",
+    )
+
+    await _record_usage(session, episode, response)
+
+    image_prompt = response.content.strip()
+    logger.info("Generated cover image prompt: %s", image_prompt)
+
+    episode_dir = os.path.join(settings.media_dir, str(episode.id))
+    os.makedirs(episode_dir, exist_ok=True)
+    filename = f"note_cover_{article_type}.png"
+    output_path = os.path.join(episode_dir, filename)
+
+    visual = get_visual_provider()
+    await visual.generate_background_image(image_prompt, output_path)
+
+    # Record Imagen cost ($0.04 per image for Imagen 4)
+    if settings.visual_provider == "google":
+        session.add(
+            ApiUsage(
+                episode_id=episode.id,
+                step_name="note_export",
+                provider="google-imagen",
+                model=settings.visual_imagen_model,
+                input_tokens=0,
+                output_tokens=0,
+                cost_usd=0.04,
+            )
+        )
+        await session.commit()
+
+    return f"{episode.id}/{filename}"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -13,6 +13,7 @@ import type {
   PromptHistory,
   PromptTemplateVersion,
   DriveExportResponse,
+  NoteArticleResponse,
   AppSettings,
   SpeakerProfile,
 } from "../types";
@@ -108,6 +109,17 @@ export const api = {
   // Drive export
   exportToDrive: (episodeId: number) =>
     client.post<DriveExportResponse>(`/episodes/${episodeId}/export/drive`),
+  // note.com articles
+  generateNoteAnalysis: (episodeId: number) =>
+    client.post<NoteArticleResponse>(`/episodes/${episodeId}/note/analysis`),
+  getNoteAnalysis: (episodeId: number) =>
+    client.get<NoteArticleResponse>(`/episodes/${episodeId}/note/analysis`),
+  generateNoteVideo: (episodeId: number) =>
+    client.post<NoteArticleResponse>(`/episodes/${episodeId}/note/video`),
+  getNoteVideo: (episodeId: number) =>
+    client.get<NoteArticleResponse>(`/episodes/${episodeId}/note/video`),
+  generateNoteCover: (episodeId: number, articleType: string) =>
+    client.post<{ episode_id: number; article_type: string; image_path: string }>(`/episodes/${episodeId}/note/${articleType}/cover`),
   // Google Drive OAuth
   getGoogleDriveAuthUrl: () =>
     client.get<{ auth_url: string }>("/auth/google/drive/url"),

--- a/frontend/src/components/EpisodeDetail.tsx
+++ b/frontend/src/components/EpisodeDetail.tsx
@@ -9,6 +9,7 @@ import { GEMINI_TTS_MODELS, GEMINI_TTS_VOICES } from "../constants/tts";
 import PipelineView from "./PipelineView";
 import ApprovalGate from "./ApprovalGate";
 import StepDataRenderer from "./step-renderers/StepDataRenderer";
+import NoteArticleSection from "./NoteArticleSection";
 
 const MEDIA_BASE_URL = "/media";
 
@@ -575,6 +576,32 @@ export default function EpisodeDetail() {
           </div>
         </PersistentDetails>
       )}
+
+      {analysisStep && analysisStep.status === "approved" && (
+        <PersistentDetails storageKey="episode-note-analysis-open" className="mb-6 bg-white rounded-lg shadow" summary={t("note.analysisTitle")}>
+          <NoteArticleSection
+            episodeId={episodeId}
+            articleType="analysis"
+            existingMarkdown={episode.note_analysis_article}
+            onGenerated={refetch}
+          />
+        </PersistentDetails>
+      )}
+
+      {(() => {
+        const vidStep = steps.find((s) => s.step_name === "video");
+        if (!vidStep || (vidStep.status !== "needs_approval" && vidStep.status !== "approved")) return null;
+        return (
+          <PersistentDetails storageKey="episode-note-video-open" className="mb-6 bg-white rounded-lg shadow" summary={t("note.videoTitle")}>
+            <NoteArticleSection
+              episodeId={episodeId}
+              articleType="video"
+              existingMarkdown={episode.note_video_article}
+              onGenerated={refetch}
+            />
+          </PersistentDetails>
+        );
+      })()}
 
       {activeStep && (
         <div className="bg-white rounded-lg shadow p-4">

--- a/frontend/src/components/NoteArticleSection.tsx
+++ b/frontend/src/components/NoteArticleSection.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { api } from "../api/client";
+
+const MEDIA_BASE_URL = "/media";
+
+interface NoteArticleSectionProps {
+  episodeId: number;
+  articleType: "analysis" | "video";
+  existingMarkdown: string | null;
+  onGenerated: () => void;
+}
+
+export default function NoteArticleSection({
+  episodeId,
+  articleType,
+  existingMarkdown,
+  onGenerated,
+}: NoteArticleSectionProps) {
+  const { t } = useTranslation();
+  const [generating, setGenerating] = useState(false);
+  const [markdown, setMarkdown] = useState<string | null>(existingMarkdown);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [generatingCover, setGeneratingCover] = useState(false);
+  const [coverPath, setCoverPath] = useState<string | null>(null);
+  const [coverError, setCoverError] = useState<string | null>(null);
+
+  // Sync with parent props when existingMarkdown changes (e.g. after refetch)
+  useEffect(() => {
+    if (existingMarkdown) {
+      setMarkdown(existingMarkdown);
+    }
+  }, [existingMarkdown]);
+
+  const handleGenerate = async () => {
+    setGenerating(true);
+    setError(null);
+    setSuccess(false);
+    try {
+      const res = articleType === "analysis"
+        ? await api.generateNoteAnalysis(episodeId)
+        : await api.generateNoteVideo(episodeId);
+      setMarkdown(res.data.markdown);
+      setSuccess(true);
+      onGenerated();
+    } catch (err) {
+      console.error("Note article generation failed:", err);
+      setError(t("note.generateFailed"));
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!markdown) return;
+    await navigator.clipboard.writeText(markdown);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleDownload = () => {
+    if (!markdown) return;
+    const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `note_${articleType}_ep${episodeId}.md`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleGenerateCover = async () => {
+    setGeneratingCover(true);
+    setCoverError(null);
+    try {
+      const res = await api.generateNoteCover(episodeId, articleType);
+      setCoverPath(res.data.image_path);
+    } catch (err) {
+      console.error("Note cover image generation failed:", err);
+      setCoverError(t("note.coverFailed"));
+    } finally {
+      setGeneratingCover(false);
+    }
+  };
+
+  return (
+    <div className="px-4 pb-4">
+      <div className="flex items-center gap-3 flex-wrap mb-3">
+        <button
+          onClick={handleGenerate}
+          disabled={generating}
+          className="px-3 py-1.5 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700 disabled:opacity-50 cursor-pointer"
+        >
+          {generating
+            ? t("note.generating")
+            : markdown
+              ? t("note.regenerate")
+              : t("note.generate")}
+        </button>
+        {markdown && (
+          <>
+            <button
+              onClick={handleCopy}
+              className="px-3 py-1.5 bg-gray-600 text-white rounded-md text-sm font-medium hover:bg-gray-700 cursor-pointer"
+            >
+              {copied ? t("note.copied") : t("note.copy")}
+            </button>
+            <button
+              onClick={handleDownload}
+              className="px-3 py-1.5 bg-gray-600 text-white rounded-md text-sm font-medium hover:bg-gray-700 cursor-pointer"
+            >
+              {t("note.download")}
+            </button>
+          </>
+        )}
+        <button
+          onClick={handleGenerateCover}
+          disabled={generatingCover}
+          className="px-3 py-1.5 bg-purple-600 text-white rounded-md text-sm font-medium hover:bg-purple-700 disabled:opacity-50 cursor-pointer"
+        >
+          {generatingCover
+            ? t("note.coverGenerating")
+            : coverPath
+              ? t("note.coverRegenerate")
+              : t("note.coverGenerate")}
+        </button>
+        {success && <span className="text-sm text-green-600">{t("note.generateSuccess")}</span>}
+        {error && <span className="text-sm text-red-600">{error}</span>}
+        {coverError && <span className="text-sm text-red-600">{coverError}</span>}
+      </div>
+      {coverPath && (
+        <div className="mb-3">
+          <p className="text-xs text-gray-500 mb-1">{t("note.coverImage")}</p>
+          <img
+            src={`${MEDIA_BASE_URL}/${coverPath}?t=${Date.now()}`}
+            alt="Cover"
+            className="max-w-md rounded border"
+          />
+          <a
+            href={`${MEDIA_BASE_URL}/${coverPath}`}
+            download
+            className="text-xs text-blue-600 hover:underline mt-1 inline-block"
+          >
+            {t("episode.download")}
+          </a>
+        </div>
+      )}
+      {markdown && (
+        <pre className="p-3 bg-gray-50 rounded border text-sm overflow-auto max-h-96 whitespace-pre-wrap font-mono">
+          {markdown}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -376,6 +376,23 @@
       "restore": "Restore"
     }
   },
+  "note": {
+    "analysisTitle": "note.com Analysis Article",
+    "videoTitle": "note.com Video Article",
+    "generate": "Generate Article",
+    "regenerate": "Regenerate",
+    "generating": "Generating...",
+    "generateFailed": "Failed to generate article",
+    "generateSuccess": "Generated!",
+    "copy": "Copy",
+    "copied": "Copied!",
+    "download": "Download (.md)",
+    "coverGenerate": "Generate Cover Image",
+    "coverRegenerate": "Regenerate Cover",
+    "coverGenerating": "Generating cover...",
+    "coverFailed": "Failed to generate cover image",
+    "coverImage": "Cover Image"
+  },
   "errors": {
     "fetchEpisodes": "Failed to fetch episodes",
     "fetchEpisode": "Failed to fetch episode"

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -376,6 +376,23 @@
       "restore": "復元"
     }
   },
+  "note": {
+    "analysisTitle": "note.com 分析記事",
+    "videoTitle": "note.com 動画紹介記事",
+    "generate": "記事を生成",
+    "regenerate": "再生成",
+    "generating": "生成中...",
+    "generateFailed": "記事の生成に失敗しました",
+    "generateSuccess": "生成完了",
+    "copy": "コピー",
+    "copied": "コピーしました",
+    "download": "ダウンロード (.md)",
+    "coverGenerate": "カバー画像を生成",
+    "coverRegenerate": "カバー画像を再生成",
+    "coverGenerating": "カバー画像生成中...",
+    "coverFailed": "カバー画像の生成に失敗しました",
+    "coverImage": "カバー画像"
+  },
   "errors": {
     "fetchEpisodes": "エピソード一覧の取得に失敗しました",
     "fetchEpisode": "エピソードの取得に失敗しました"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -41,6 +41,8 @@ export interface Episode {
   drive_file_id: string | null;
   drive_file_url: string | null;
   shorts_enabled: boolean;
+  note_analysis_article: string | null;
+  note_video_article: string | null;
   pipeline_steps: PipelineStep[];
 }
 
@@ -172,6 +174,14 @@ export interface DriveExportResponse {
   drive_file_id: string;
   drive_file_url: string;
   source_text_length: number;
+  input_tokens: number;
+  output_tokens: number;
+}
+
+export interface NoteArticleResponse {
+  episode_id: number;
+  article_type: string;
+  markdown: string;
   input_tokens: number;
   output_tokens: number;
 }


### PR DESCRIPTION
## Summary
- note.com 用マークダウン記事を AI で自動生成（分析記事・動画紹介記事の2種類）
- プレビュー・クリップボードコピー・.md ダウンロード対応
- Imagen 4 によるカバー画像生成ボタン追加
- コスト記録: AI テキスト生成 + Imagen 4 ($0.04/枚) を ApiUsage に記録
- プロンプトテンプレートは設定画面から編集可能

## 変更ファイル (12ファイル)
### 新規
- `backend/alembic/versions/018_add_note_article_columns.py` — DB マイグレーション
- `backend/app/services/note_article.py` — 記事生成サービス + カバー画像生成
- `frontend/src/components/NoteArticleSection.tsx` — 生成/プレビュー/コピー/DL コンポーネント

### 変更
- `backend/app/models/episode.py` — note_analysis_article, note_video_article カラム
- `backend/app/api/episodes.py` — 5 エンドポイント追加 (POST/GET x2 + cover)
- `backend/app/api/schemas.py` — NoteArticleResponse + EpisodeResponse 拡張
- `backend/app/api/prompts.py` — 2プロンプトキー登録
- `frontend/src/types/index.ts` — Episode, NoteArticleResponse 型追加
- `frontend/src/api/client.ts` — API メソッド5つ追加
- `frontend/src/components/EpisodeDetail.tsx` — NoteArticleSection 統合
- `frontend/src/locales/ja.json` / `en.json` — i18n キー追加

## Test plan
- [x] マイグレーション実行成功
- [x] Ruff lint/format パス
- [x] フロントエンド表示確認
- [x] 分析記事生成・保存・表示確認
- [ ] 動画紹介記事生成確認
- [ ] カバー画像生成確認
- [ ] 設定画面でプロンプトテンプレート表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)