### PR TITLE
fix: 品質向上フェーズ — 音声ハング修正・深層調査軽量化・台本バリエーション改善

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -69,7 +69,7 @@ class Settings(BaseSettings):
 
     # Deep investigation (Phase 7)
     collection_deep_investigation_enabled: bool = False
-    collection_deep_investigation_max_rounds: int = 3
+    collection_deep_investigation_max_rounds: int = 1
     collection_deep_investigation_max_cost_usd: float = 1.0
     collection_deep_investigation_provider: str = ""
     collection_deep_investigation_model: str = ""
@@ -91,6 +91,7 @@ class Settings(BaseSettings):
     gemini_tts_model: str = "gemini-2.5-flash-preview-tts"
     gemini_tts_voice: str = "Kore"  # Prebuilt voice name
     gemini_tts_instructions: str = "落ち着いたニュースキャスターのように、明瞭で聞き取りやすく話してください"
+    tts_chunk_timeout: int = 120  # Timeout per TTS chunk in seconds
 
     # Sound Effects (SE)
     se_intro: str = "intro_chime"  # Preset name or "none"

--- a/backend/app/pipeline/scriptwriter.py
+++ b/backend/app/pipeline/scriptwriter.py
@@ -329,18 +329,25 @@ class ScriptwriterStep(BaseStep):
             raise ValueError("No reliable news items to generate scripts for")
 
         # Phase 1: per-article scripts (with mode selection)
+        # Track previous approaches to avoid repetition
+        prev_approaches: list[str] = []
         for i, item in enumerate(items):
             mode = self._determine_script_mode(item, settings.script_default_mode)
+            variation_hint = self._build_variation_hint(item, i, len(items), prev_approaches)
             if mode == "explainer":
                 await self.log_progress(episode_id, f"[{i + 1}/{len(items)}] 「{item.title[:30]}」の対話台本を生成中")
                 result = await self._script_item_explainer(
                     item, provider, model, explainer_prompt, session, episode_id,
-                    all_items, speakers_by_role,
+                    all_items, speakers_by_role, variation_hint=variation_hint,
                 )
             else:
                 await self.log_progress(episode_id, f"[{i + 1}/{len(items)}] 「{item.title[:30]}」の台本を生成中")
-                result = await self._script_item(item, provider, model, item_prompt, session, episode_id, all_items)
+                result = await self._script_item(
+                    item, provider, model, item_prompt, session, episode_id, all_items,
+                    variation_hint=variation_hint,
+                )
             item_scripts.append(result)
+            prev_approaches.append(result.get("approach", "standard"))
             total_input_tokens += result["input_tokens"]
             total_output_tokens += result["output_tokens"]
 
@@ -408,6 +415,53 @@ class ScriptwriterStep(BaseStep):
             result["shorts"] = shorts_data
         return result
 
+    def _build_variation_hint(
+        self,
+        item: NewsItem,
+        index: int,
+        total: int,
+        prev_approaches: list[str],
+    ) -> str:
+        """Build a hint for the AI to vary script structure based on context."""
+        parts: list[str] = []
+
+        # News type classification from analysis
+        news_type = "general"
+        if item.analysis_data and isinstance(item.analysis_data, dict):
+            ad = item.analysis_data
+            perspectives = ad.get("perspectives", [])
+            has_data = bool(ad.get("data_validation"))
+            has_controversy = len(perspectives) >= 3
+            severity = ad.get("severity", "")
+
+            if severity in ("critical", "urgent"):
+                news_type = "breaking"
+            elif has_controversy:
+                news_type = "controversy"
+            elif has_data:
+                news_type = "data"
+            else:
+                news_type = "analysis"
+
+        type_hints = {
+            "breaking": "速報系: 事実→背景→影響の順で短く鋭く。緊張感のあるテンポで",
+            "controversy": "論争系: 対立する意見を交互に提示し、リスナーに判断材料を渡す構成で",
+            "data": "データ系: 数字・統計から入り、その意味を解きほぐす構成で。スケール変換を多用",
+            "analysis": "解説系: 問いかけから入り、背景→複数視点→まとめの流れで",
+            "general": "自由な構成で。ニュースの性質に最も合う入り方を選んでください",
+        }
+        parts.append(f"[ニュース種別] {type_hints.get(news_type, type_hints['general'])}")
+
+        # Position context
+        parts.append(f"[位置] {index + 1}番目/{total}件")
+
+        # Anti-repetition: tell what previous items used
+        if prev_approaches:
+            parts.append(f"[前のニュースで使ったアプローチ] {', '.join(prev_approaches[-3:])}")
+            parts.append("※ 前のニュースと異なるつかみ・構成パターンを使ってください")
+
+        return "\n".join(parts)
+
     async def _script_item(
         self,
         item: NewsItem,
@@ -417,6 +471,7 @@ class ScriptwriterStep(BaseStep):
         session: AsyncSession,
         episode_id: int,
         all_items: list[NewsItem] | None = None,
+        variation_hint: str = "",
     ) -> dict:
         """Generate a script for a single news item."""
         analysis_info = ""
@@ -459,6 +514,8 @@ class ScriptwriterStep(BaseStep):
             f"{analysis_info}"
             f"{group_sources_info}"
         )
+        if variation_hint:
+            prompt += f"\n\n## バリエーション指示\n{variation_hint}"
 
         response = await provider.generate(
             prompt=prompt,
@@ -467,7 +524,8 @@ class ScriptwriterStep(BaseStep):
         )
 
         data = parse_json_response(response.content)
-        item.script_text = data.get("script_text", "")
+        script_text = data.get("script_text", "")
+        item.script_text = script_text
         item.script_mode = "solo"
         item.script_data = {"illustration_prompt": data.get("illustration_prompt", "")}
 
@@ -480,10 +538,14 @@ class ScriptwriterStep(BaseStep):
             output_tokens=response.output_tokens,
         )
 
+        # Detect approach used for anti-repetition tracking
+        approach = self._detect_approach(script_text)
+
         return {
             "news_item_id": item.id,
             "title": item.title,
             "mode": "solo",
+            "approach": approach,
             "input_tokens": response.input_tokens,
             "output_tokens": response.output_tokens,
         }
@@ -510,6 +572,26 @@ class ScriptwriterStep(BaseStep):
 
         return "solo"
 
+    @staticmethod
+    def _detect_approach(script_text: str) -> str:
+        """Detect the opening approach used in a script for anti-repetition tracking."""
+        if not script_text:
+            return "narrative"
+        first_line = script_text.split("\n")[0]
+        # Strip speaker name prefix for explainer mode (e.g., "MC名: ")
+        if ": " in first_line:
+            first_line = first_line.split(": ", 1)[1]
+        # Simple heuristic based on opening patterns
+        if "？" in first_line or "ですか" in first_line:
+            return "question"
+        if any(c.isdigit() for c in first_line[:30]):
+            return "number"
+        if "実は" in first_line or "知って" in first_line:
+            return "surprising_fact"
+        if "さて" in first_line or "続いて" in first_line:
+            return "transition"
+        return "narrative"
+
     async def _script_item_explainer(
         self,
         item: NewsItem,
@@ -520,6 +602,7 @@ class ScriptwriterStep(BaseStep):
         episode_id: int,
         all_items: list[NewsItem] | None = None,
         speakers_by_role: dict[str, SpeakerProfile] | None = None,
+        variation_hint: str = "",
     ) -> dict:
         """Generate a dialogue-style script for a news item (explainer mode)."""
         analysis_info = ""
@@ -561,6 +644,8 @@ class ScriptwriterStep(BaseStep):
             f"{analysis_info}"
             f"{group_sources_info}"
         )
+        if variation_hint:
+            prompt += f"\n\n## バリエーション指示\n{variation_hint}"
 
         response = await provider.generate(
             prompt=prompt,
@@ -593,7 +678,8 @@ class ScriptwriterStep(BaseStep):
             speaker = turn.get("speaker", "speaker_a")
             name = speaker_a_name if speaker == "speaker_a" else speaker_b_name
             flat_lines.append(f"{name}: {turn.get('text', '')}")
-        item.script_text = "\n".join(flat_lines)
+        flat_text = "\n".join(flat_lines)
+        item.script_text = flat_text
 
         await self.record_usage(
             session=session,
@@ -604,10 +690,13 @@ class ScriptwriterStep(BaseStep):
             output_tokens=response.output_tokens,
         )
 
+        approach = self._detect_approach(flat_text)
+
         return {
             "news_item_id": item.id,
             "title": item.title,
             "mode": "explainer",
+            "approach": approach,
             "input_tokens": response.input_tokens,
             "output_tokens": response.output_tokens,
         }

--- a/backend/app/pipeline/voice.py
+++ b/backend/app/pipeline/voice.py
@@ -128,9 +128,9 @@ class VoiceStep(BaseStep):
         sample_rate = 24000  # Default; updated after first TTS output
         elapsed = 0.0  # Cumulative time tracking for accurate SRT timestamps
 
+        intro_se_inserted = False
         for i, section in enumerate(sections):
             tts_text = self._prepare_tts_text(section["text"], pronunciations)
-            total_chars += len(section["text"])
 
             # Convert to SSML for natural prosody (Google TTS only)
             await self.log_progress(episode_id, f"[{i + 1}/{len(sections)}] 「{section['label'][:30]}」を音声合成中")
@@ -154,33 +154,47 @@ class VoiceStep(BaseStep):
 
             # Use multi-speaker for dialogue sections, single-speaker otherwise
             script_data = section.get("script_data")
-            if (
-                script_data
-                and isinstance(script_data, dict)
-                and script_data.get("mode") == "explainer"
-                and multi_provider
-            ):
-                dialogue = script_data.get("dialogue", [])
-                # Apply pronunciation to each dialogue turn
-                processed_dialogue = []
-                for turn in dialogue:
-                    processed_text = self._prepare_tts_text(turn.get("text", ""), pronunciations)
-                    processed_dialogue.append({"speaker": turn.get("speaker", "speaker_a"), "text": processed_text})
-                audio_bytes = await multi_provider.synthesize_dialogue(processed_dialogue)
-                logger.info(
-                    "Episode %d: multi-speaker synthesis for section '%s' (%d turns)",
-                    episode_id, section["key"], len(dialogue),
+            try:
+                if (
+                    script_data
+                    and isinstance(script_data, dict)
+                    and script_data.get("mode") == "explainer"
+                    and multi_provider
+                ):
+                    dialogue = script_data.get("dialogue", [])
+                    # Apply pronunciation to each dialogue turn
+                    processed_dialogue = []
+                    for turn in dialogue:
+                        processed_text = self._prepare_tts_text(turn.get("text", ""), pronunciations)
+                        processed_dialogue.append({"speaker": turn.get("speaker", "speaker_a"), "text": processed_text})
+                    audio_bytes = await multi_provider.synthesize_dialogue(processed_dialogue)
+                    logger.info(
+                        "Episode %d: multi-speaker synthesis for section '%s' (%d turns)",
+                        episode_id, section["key"], len(dialogue),
+                    )
+                else:
+                    audio_bytes = await provider.synthesize(tts_input)
+            except TimeoutError:
+                logger.error(
+                    "Episode %d: TTS timed out for section '%s', skipping",
+                    episode_id, section["key"],
                 )
-            else:
-                audio_bytes = await provider.synthesize(tts_input)
+                await self.log_progress(
+                    episode_id,
+                    f"⚠ 「{section['label'][:30]}」の音声合成がタイムアウトしました。スキップします。"
+                )
+                continue
+
+            total_chars += len(section["text"])
 
             # Generate silence chunk matching the sample rate of the first WAV
             if silence_chunk is None and audio_format == "wav":
                 sample_rate = self._get_wav_sample_rate(audio_bytes)
                 silence_chunk = self._generate_silence(_silence_seconds(), audio_format, sample_rate)
 
-            # Insert intro SE before the very first section
-            if i == 0 and audio_format == "wav":
+            # Insert intro SE before the first successfully synthesized section
+            if not intro_se_inserted and audio_format == "wav":
+                intro_se_inserted = True
                 se_intro = load_se(settings.se_intro, sample_rate)
                 if se_intro:
                     all_audio_chunks.append(se_intro)
@@ -317,16 +331,20 @@ class VoiceStep(BaseStep):
                     f"ショート音声 [{i + 1}/{len(shorts_input)}] を生成中"
                 )
 
-                if mode == "explainer" and multi_provider and short.get("dialogue"):
-                    dialogue = short["dialogue"]
-                    processed = [
-                        {"speaker": t.get("speaker", "speaker_a"), "text": self._prepare_tts_text(t.get("text", ""), pronunciations)}
-                        for t in dialogue
-                    ]
-                    short_audio = await multi_provider.synthesize_dialogue(processed)
-                else:
-                    short_text = self._prepare_tts_text(short.get("text", ""), pronunciations)
-                    short_audio = await provider.synthesize(short_text)
+                try:
+                    if mode == "explainer" and multi_provider and short.get("dialogue"):
+                        dialogue = short["dialogue"]
+                        processed = [
+                            {"speaker": t.get("speaker", "speaker_a"), "text": self._prepare_tts_text(t.get("text", ""), pronunciations)}
+                            for t in dialogue
+                        ]
+                        short_audio = await multi_provider.synthesize_dialogue(processed)
+                    else:
+                        short_text = self._prepare_tts_text(short.get("text", ""), pronunciations)
+                        short_audio = await provider.synthesize(short_text)
+                except TimeoutError:
+                    logger.error("Episode %d: TTS timed out for short %s, skipping", episode_id, item_id)
+                    continue
 
                 short_filename = f"short_{item_id}.{audio_format}"
                 short_path = os.path.join(shorts_dir, short_filename)

--- a/backend/app/services/tts_gemini.py
+++ b/backend/app/services/tts_gemini.py
@@ -5,6 +5,7 @@ Unlike Google Cloud TTS (Neural2), this uses LLM-based speech generation
 with natural language style control.
 """
 
+import asyncio
 import io
 import logging
 import wave
@@ -70,8 +71,11 @@ class GeminiTTSProvider(TTSProvider):
 
         return concatenate_wav(audio_chunks)
 
-    async def _synthesize_chunk(self, text: str) -> bytes:
-        """Synthesize a single chunk, returning raw PCM bytes."""
+    async def _synthesize_chunk(self, text: str, retry: bool = True) -> bytes:
+        """Synthesize a single chunk, returning raw PCM bytes.
+
+        Applies a per-chunk timeout and retries once on timeout.
+        """
         # Prepend style instructions if configured
         if self._instructions:
             content = f"{self._instructions}: {text}"
@@ -89,11 +93,26 @@ class GeminiTTSProvider(TTSProvider):
             ),
         )
 
-        response = await self._client.aio.models.generate_content(
-            model=self._model,
-            contents=content,
-            config=config,
-        )
+        timeout = settings.tts_chunk_timeout
+        try:
+            response = await asyncio.wait_for(
+                self._client.aio.models.generate_content(
+                    model=self._model,
+                    contents=content,
+                    config=config,
+                ),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            if retry:
+                logger.warning(
+                    "Gemini TTS chunk timed out after %ds (%d chars), retrying once",
+                    timeout, len(text),
+                )
+                return await self._synthesize_chunk(text, retry=False)
+            raise TimeoutError(
+                f"Gemini TTS chunk timed out after {timeout}s ({len(text)} chars)"
+            )
 
         pcm_data = response.candidates[0].content.parts[0].inline_data.data
 

--- a/backend/app/services/tts_gemini_multi.py
+++ b/backend/app/services/tts_gemini_multi.py
@@ -4,6 +4,7 @@ Uses Gemini 2.5 Flash/Pro TTS models with MultiSpeakerMarkup for
 natural two-speaker dialogue synthesis (max 2 speakers).
 """
 
+import asyncio
 import io
 import logging
 import wave
@@ -136,12 +137,7 @@ class GeminiMultiSpeakerTTSProvider(TTSProvider):
                 ),
             )
 
-            response = await self._client.aio.models.generate_content(
-                model=self._model,
-                contents=content,
-                config=config,
-            )
-
+            response = await self._generate_with_retry(content, config, len(chunk))
             pcm_data = response.candidates[0].content.parts[0].inline_data.data
 
             if response.usage_metadata:
@@ -158,6 +154,31 @@ class GeminiMultiSpeakerTTSProvider(TTSProvider):
             )
 
         return concatenate_wav(audio_chunks) if len(audio_chunks) > 1 else audio_chunks[0]
+
+    async def _generate_with_retry(self, content: str, config: types.GenerateContentConfig, chunk_chars: int):
+        """Call Gemini API with timeout and one retry."""
+        timeout = settings.tts_chunk_timeout
+        for attempt in range(2):
+            try:
+                return await asyncio.wait_for(
+                    self._client.aio.models.generate_content(
+                        model=self._model,
+                        contents=content,
+                        config=config,
+                    ),
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError:
+                if attempt == 0:
+                    logger.warning(
+                        "Gemini MultiSpeaker TTS chunk timed out after %ds (%d chars), retrying once",
+                        timeout, chunk_chars,
+                    )
+                else:
+                    raise TimeoutError(
+                        f"Gemini MultiSpeaker TTS chunk timed out after {timeout}s ({chunk_chars} chars)"
+                    )
+        raise TimeoutError("Unreachable")  # satisfy type checker
 
     def _pcm_to_wav(self, pcm_data: bytes) -> bytes:
         """Wrap raw PCM data in a WAV header."""


### PR DESCRIPTION
## Summary

Epic #123 の子Issue 3件をまとめて対応。

- **#122 音声生成ハング修正**: Gemini TTS にチャンク単位タイムアウト(120s)+1回リトライを追加。セクションがタイムアウトした場合はスキップして残りを継続。shorts合成にも同様の保護を追加
- **#125 deep investigation 軽量化**: デフォルト `max_rounds` を 3→1 に変更（overall timeout 15分→5分）
- **#124 台本バリエーション改善**: 分析結果からニュース種別を判定（速報/論争/データ/解説）し、前のニュースで使ったアプローチをトラッキングして同じパターンの繰り返しを防止

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `config.py` | `tts_chunk_timeout` 追加、`max_rounds` 3→1 |
| `tts_gemini.py` | `asyncio.wait_for` + retry in `_synthesize_chunk` |
| `tts_gemini_multi.py` | `_generate_with_retry` メソッド抽出 |
| `voice.py` | `TimeoutError` catch + skip、intro SE フラグ化、shorts保護 |
| `scriptwriter.py` | `_build_variation_hint`, `_detect_approach` 追加 |

## Test plan

- [ ] 長い台本(12記事)でvoiceステップがタイムアウト後もスキップして完了すること
- [ ] 短い台本で通常通り音声生成が成功すること
- [ ] deep investigation が1ラウンドで完了すること
- [ ] 複数ニュースの台本で冒頭パターンがバリエーション指示に従って変化すること

Closes #122, Closes #124, Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)