### PR TITLE
feat: Claude Code Skills & Hooks でワークフロー自動化

### DIFF
--- a/.claude/hooks/poll-step-completion.sh
+++ b/.claude/hooks/poll-step-completion.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Poll pipeline step completion after run_step is called.
+set -euo pipefail
+
+INPUT=$(cat)
+EPISODE_ID=$(echo "$INPUT" | jq -r '.tool_input.episode_id // empty')
+STEP_NAME=$(echo "$INPUT" | jq -r '.tool_input.step_name // empty')
+
+if [ -z "$EPISODE_ID" ] || [ -z "$STEP_NAME" ]; then
+  exit 0
+fi
+
+BACKEND_URL="${AINEWSRADIO_BACKEND_URL:-http://localhost:8000}"
+MAX_ATTEMPTS=40
+ATTEMPT=0
+
+while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+  sleep 15
+  ATTEMPT=$((ATTEMPT + 1))
+
+  RESPONSE=$(curl -s --connect-timeout 5 "${BACKEND_URL}/api/episodes/${EPISODE_ID}" 2>/dev/null || echo '{}')
+  STATUS=$(echo "$RESPONSE" | jq -r ".pipeline_steps[]? | select(.step_name == \"${STEP_NAME}\") | .status" 2>/dev/null || echo "unknown")
+
+  case "$STATUS" in
+    needs_approval)
+      echo "Step '${STEP_NAME}' for episode #${EPISODE_ID} completed and needs approval."
+      exit 0
+      ;;
+    pending)
+      echo "Step '${STEP_NAME}' for episode #${EPISODE_ID} failed (reset to pending). Check get_episode_status for errors."
+      exit 0
+      ;;
+    running)
+      ;;
+    approved|rejected)
+      echo "Step '${STEP_NAME}' for episode #${EPISODE_ID} is already ${STATUS}."
+      exit 0
+      ;;
+  esac
+done
+
+echo "Step '${STEP_NAME}' for episode #${EPISODE_ID} still running after 10 minutes. Check manually."

--- a/.claude/hooks/post-search.sh
+++ b/.claude/hooks/post-search.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# After search_news, remind about episode creation.
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_OUTPUT=$(echo "$INPUT" | jq -r '.tool_output // empty')
+
+if echo "$TOOL_OUTPUT" | grep -q "results)"; then
+  RESULT_COUNT=$(echo "$TOOL_OUTPUT" | grep -oP '\((\d+) results\)' | grep -oP '\d+' || true)
+  if [ -n "$RESULT_COUNT" ] && [ "$RESULT_COUNT" -gt 0 ]; then
+    echo "${RESULT_COUNT} results found. Ask the user which articles to include in an episode."
+  fi
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Session start: check backend health and report pending episodes.
+set -euo pipefail
+
+BACKEND_URL="${AINEWSRADIO_BACKEND_URL:-http://localhost:8000}"
+
+# Health check
+HEALTH=$(curl -s --connect-timeout 3 "${BACKEND_URL}/api/health" 2>/dev/null || echo '{"status":"unreachable"}')
+HEALTH_STATUS=$(echo "$HEALTH" | jq -r '.status // "unreachable"')
+
+if [ "$HEALTH_STATUS" != "ok" ]; then
+  echo "WARNING: Backend not reachable (status: ${HEALTH_STATUS}). Start with: docker compose up -d"
+  exit 0
+fi
+
+# Check for episodes needing attention
+EPISODES=$(curl -s --connect-timeout 5 "${BACKEND_URL}/api/episodes" 2>/dev/null || echo '[]')
+TOTAL=$(echo "$EPISODES" | jq 'if type == "array" then length else 0 end')
+
+PENDING=0
+RUNNING=0
+for row in $(echo "$EPISODES" | jq -r '.[]? | @base64' 2>/dev/null); do
+  EP=$(echo "$row" | base64 -d)
+  EP_ID=$(echo "$EP" | jq -r '.id')
+  EP_STATUS=$(echo "$EP" | jq -r '.status')
+
+  if [ "$EP_STATUS" = "in_progress" ]; then
+    DETAIL=$(curl -s --connect-timeout 3 "${BACKEND_URL}/api/episodes/${EP_ID}" 2>/dev/null || echo '{}')
+    P=$(echo "$DETAIL" | jq '[.pipeline_steps[]? | select(.status == "needs_approval")] | length' 2>/dev/null || echo 0)
+    R=$(echo "$DETAIL" | jq '[.pipeline_steps[]? | select(.status == "running")] | length' 2>/dev/null || echo 0)
+    PENDING=$((PENDING + P))
+    RUNNING=$((RUNNING + R))
+  fi
+done
+
+OUTPUT="Backend: OK | Episodes: ${TOTAL}"
+[ "$PENDING" -gt 0 ] && OUTPUT="${OUTPUT} | Pending approvals: ${PENDING}"
+[ "$RUNNING" -gt 0 ] && OUTPUT="${OUTPUT} | Running steps: ${RUNNING}"
+echo "$OUTPUT"

--- a/.claude/hooks/session-stop.sh
+++ b/.claude/hooks/session-stop.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Before session ends, check for pending work.
+set -euo pipefail
+
+BACKEND_URL="${AINEWSRADIO_BACKEND_URL:-http://localhost:8000}"
+
+EPISODES=$(curl -s --connect-timeout 3 "${BACKEND_URL}/api/episodes" 2>/dev/null || echo '[]')
+
+AWAITING=""
+for row in $(echo "$EPISODES" | jq -r '.[]? | @base64' 2>/dev/null); do
+  EP=$(echo "$row" | base64 -d)
+  EP_ID=$(echo "$EP" | jq -r '.id')
+  EP_TITLE=$(echo "$EP" | jq -r '.title')
+  EP_STATUS=$(echo "$EP" | jq -r '.status')
+
+  if [ "$EP_STATUS" = "in_progress" ]; then
+    DETAIL=$(curl -s --connect-timeout 3 "${BACKEND_URL}/api/episodes/${EP_ID}" 2>/dev/null || echo '{}')
+    PENDING_STEPS=$(echo "$DETAIL" | jq -r '[.pipeline_steps[]? | select(.status == "needs_approval") | .step_name] | join(", ")' 2>/dev/null || true)
+    if [ -n "$PENDING_STEPS" ]; then
+      AWAITING="${AWAITING}\n  #${EP_ID} ${EP_TITLE}: ${PENDING_STEPS} awaiting approval"
+    fi
+  fi
+done
+
+if [ -n "$AWAITING" ]; then
+  echo -e "Reminder — episodes with pending approvals:${AWAITING}"
+fi

--- a/.claude/hooks/suggest-next-step.sh
+++ b/.claude/hooks/suggest-next-step.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# After approving a step, suggest the next pipeline step.
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_OUTPUT=$(echo "$INPUT" | jq -r '.tool_output // empty')
+EPISODE_ID=$(echo "$INPUT" | jq -r '.tool_input.episode_id // empty')
+
+if echo "$TOOL_OUTPUT" | grep -q "Next step:"; then
+  NEXT_STEP=$(echo "$TOOL_OUTPUT" | grep -oP "step_name='\\K[^']+" || true)
+  if [ -n "$NEXT_STEP" ] && [ -n "$EPISODE_ID" ]; then
+    echo "Next step available: ${NEXT_STEP} for episode #${EPISODE_ID}. Ask the user if they want to proceed."
+  fi
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,54 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "mcp__ai-news-radio__run_step",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/poll-step-completion.sh\"",
+            "timeout": 660
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__ai-news-radio__approve_step",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/suggest-next-step.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__ai-news-radio__search_news",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-search.sh\""
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-stop.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/costs/SKILL.md
+++ b/.claude/skills/costs/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: costs
+description: Show API cost summary with breakdown by provider and step, plus optimization suggestions
+argument-hint: [today|week|month|episode_id]
+---
+
+# /costs — Cost Summary and Optimization
+
+Show API cost statistics and provide optimization suggestions.
+
+## Arguments
+- Period (optional): "today", "week", "month", or an episode ID number
+- Default: past 7 days
+
+## Workflow
+
+### Step 1: Gather Data
+Use `get_cost_stats` with appropriate filters:
+- "today" → from_date = today
+- "week" → from_date = 7 days ago
+- "month" → from_date = 30 days ago
+- Number → episode_id filter
+
+### Step 2: Present Summary
+Format results as a clear report:
+
+```
+=== API Cost Report (期間: YYYY-MM-DD 〜 YYYY-MM-DD) ===
+
+Total: $X.XX (約 ¥XXX)
+
+Provider別:
+  - OpenAI:    $X.XX (XX%)
+  - Anthropic: $X.XX (XX%)
+  - Google:    $X.XX (XX%)
+  - Brave:     $X.XX (XX%)
+
+Step別:
+  - collection: $X.XX
+  - factcheck:  $X.XX
+  - analysis:   $X.XX
+  - script:     $X.XX
+  - voice:      $X.XX
+  - video:      $X.XX
+```
+
+Use 1 USD ≈ 150 JPY as rough conversion.
+
+### Step 3: Optimization Suggestions
+Based on the data:
+- If factcheck/analysis costs are high → suggest lighter models
+- If voice costs dominate → note alternative TTS providers
+- If video/imagen costs are high → mention static fallback option
+- Flag any unusually expensive episodes
+
+## Notes
+- Present costs with appropriate precision ($0.0012, not $0.00)
+- Always include the date range in the header

--- a/.claude/skills/episode/SKILL.md
+++ b/.claude/skills/episode/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: episode
+description: Interactive episode creation workflow — search news, select articles, create episode, and optionally start factcheck
+argument-hint: [topic]
+---
+
+# /episode — Episode Creation Workflow
+
+Guide the user through creating a new episode step by step.
+
+## Workflow
+
+### Step 1: Topic Selection
+If the user provided a topic as argument, use it. Otherwise ask what topic/theme they want to cover.
+
+### Step 2: News Search
+Use `search_news` to find articles about the topic:
+- Search with source=brave (freshness=pw for past week by default)
+- Also search with source=youtube to find video sources
+- Run both searches in parallel if possible
+
+Present results in a numbered list:
+```
+1. [Brave] タイトル — ソース名
+   URL: https://...
+2. [YouTube] タイトル — チャンネル名
+   URL: https://youtube.com/...
+```
+
+### Step 3: Article Selection
+Ask the user which articles to include:
+- Accept comma-separated numbers: "1,3,5"
+- Accept ranges: "1-5"
+- Accept "all" for everything
+- Accept additional search requests if results are insufficient
+
+### Step 4: Episode Title
+Ask for a title, or suggest one based on the selected articles.
+
+### Step 5: Create Episode
+Use `create_episode_from_articles` with the title and selected articles.
+
+### Step 6: Next Steps
+Show the created episode status and ask:
+"ファクトチェックを実行しますか？"
+If yes, use `run_step` with step_name=factcheck.
+
+## Notes
+- Always show article sources and URLs so the user can verify quality
+- If search returns no results, suggest broadening the query or different keywords
+- The user can cancel at any step by saying "cancel" or "やめる"

--- a/.claude/skills/note/SKILL.md
+++ b/.claude/skills/note/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: note
+description: Generate a note.com article from an episode — prerequisite checks, generation, preview, and cover image
+argument-hint: <episode_id> [analysis|video]
+---
+
+# /note — Generate note.com Article
+
+Generate a note.com article from an episode's analysis or video data.
+
+## Arguments
+- Episode ID (required): e.g., `/note 42`
+- Article type (optional): "analysis" or "video"
+
+## Workflow
+
+### Step 1: Check Prerequisites
+Use `get_episode_status` to verify:
+- For analysis article: analysis step must be `approved`
+- For video article: video step must be `needs_approval` or `approved`
+
+If prerequisites are not met, explain what needs to happen first.
+Offer to run missing steps with `/pipeline`.
+
+### Step 2: Auto-detect Type
+If article type was not specified:
+- If video step is completed/approved: ask "分析記事と動画紹介記事のどちらを生成しますか？"
+- If only analysis is approved: default to analysis article
+
+### Step 3: Generate Article
+Call the backend API:
+```bash
+curl -s -X POST http://localhost:8000/api/episodes/{episode_id}/note/{article_type}
+```
+Parse the response JSON for the markdown content.
+
+### Step 4: Preview
+Display the generated markdown article.
+Highlight:
+- Title (first H1 line)
+- Hashtags (usually the last line)
+- Embedded YouTube URLs (if any)
+- Approximate word count
+
+### Step 5: Cover Image (Optional)
+Ask: "カバー画像も生成しますか？ (Y/n)"
+If yes:
+```bash
+curl -s -X POST http://localhost:8000/api/episodes/{episode_id}/note/{article_type}/cover
+```
+Show the image path from the response.
+
+### Step 6: Usage Instructions
+Tell the user:
+- The markdown is ready to paste into note.com's editor
+- Copy hashtags separately for note.com's tag field
+- Cover image path for upload
+- Remind to review formatting after pasting
+
+## Notes
+- Note article generation is not exposed via MCP tools, so use REST API directly via curl
+- Always display the full article for user review

--- a/.claude/skills/pipeline/SKILL.md
+++ b/.claude/skills/pipeline/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: pipeline
+description: Run the next pending pipeline step for an episode — auto-detect, execute, monitor, and review
+argument-hint: <episode_id>
+---
+
+# /pipeline — Run Next Pipeline Step
+
+Run the next pending pipeline step for an episode.
+
+## Arguments
+- Episode ID (required): provided as argument (e.g., `/pipeline 42`)
+- If no argument, ask the user for the episode ID
+
+## Workflow
+
+### Step 1: Check Status
+Use `get_episode_status` to determine the current state of all pipeline steps.
+
+### Step 2: Identify Next Action
+Examine each step in order (collection → factcheck → analysis → script → voice → video):
+
+- If a step is `needs_approval`: Show results summary and ask user to approve/reject
+- If a step is `running`: Report it's still running and wait
+- If a step is `pending` AND the previous step is `approved`: This is the next step to run
+- If all steps are `approved` or the episode is `completed`: Report pipeline is complete
+
+### Step 3: Run the Step
+Use `run_step` with the identified step name.
+- For voice step: Ask about TTS model/voice preferences if desired
+- For video step: Ask about video_targets if this is a re-run
+
+### Step 4: Monitor Completion
+Poll with `get_episode_status` every 15-20 seconds until the step transitions from `running`.
+Show brief progress updates.
+
+### Step 5: Review Results
+When the step completes (`needs_approval`):
+- Use `get_step_detail` to get detailed output
+- **factcheck**: Show fact-check scores per item, flag scores below 3
+- **analysis**: Show severity summary, perspective count, media bias if present
+- **script**: Show the episode script text for review
+- **voice**: Report audio file generation status
+- **video**: Report video/thumbnail generation status
+
+### Step 6: Approval
+Ask the user:
+- "承認" / "approve" → `approve_step`
+- "却下 [理由]" / "reject [reason]" → `reject_step`
+- "除外 1,3" / "exclude 1,3" → `approve_step` with `excluded_item_ids`
+
+After approval, ask: "次のステップに進みますか？"
+
+## Notes
+- If a step fails (resets to pending), show the error and ask whether to retry
+- Always show the episode title and current pipeline state before taking action

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: publish
+description: Publish a completed episode — export to Google Drive, generate note.com articles, mark as complete
+argument-hint: <episode_id>
+---
+
+# /publish — Episode Publishing Workflow
+
+Guide the user through publishing a completed episode.
+
+## Arguments
+- Episode ID (required): e.g., `/publish 42`
+
+## Workflow
+
+### Step 1: Check Readiness
+Use `get_episode_status` to check which steps are approved.
+Report what's available:
+
+| Action | Requires |
+|--------|----------|
+| Google Drive Export | analysis approved |
+| note.com Analysis Article | analysis approved |
+| note.com Video Article | video approved |
+| Mark Complete | any state (always available) |
+
+### Step 2: Publishing Menu
+Present available actions as numbered list:
+```
+利用可能な公開アクション:
+1. Google Drive エクスポート
+2. note.com 分析記事
+3. note.com 動画紹介記事
+4. 完了マーク
+```
+
+Ask which to perform. Allow multiple selections (e.g., "1,2,4").
+
+### Step 3: Execute
+Run selected actions in order:
+
+1. **Google Drive**: Use `export_to_drive` with episode_id. Show the Drive URL.
+2. **note.com Analysis**: Call `curl -s -X POST http://localhost:8000/api/episodes/{id}/note/analysis`. Show preview.
+3. **note.com Video**: Call `curl -s -X POST http://localhost:8000/api/episodes/{id}/note/video`. Show preview.
+4. **Mark Complete**: Use `toggle_complete` with episode_id.
+
+### Step 4: Summary
+Show a final summary:
+- Drive file URL (if exported)
+- Note article titles and hashtags (if generated)
+- Episode final status
+
+## Notes
+- If Google Drive is not authenticated, skip that option and explain setup
+- Always execute "Mark Complete" last (after other exports)
+- Show cost of each action if tokens were used

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: research
+description: Deep multi-source research on a topic using Brave Search and YouTube, with synthesis report
+argument-hint: <topic>
+context: fork
+---
+
+# /research — Deep Multi-Source Research
+
+Conduct thorough research on a topic using multiple sources and present a synthesis.
+
+## Arguments
+- Topic (required): e.g., `/research 熊本TSMC最新動向`
+
+## Workflow
+
+### Step 1: Query Expansion
+From the user's topic, generate 3-5 search queries covering different angles:
+- Main topic query (Japanese if Japanese topic)
+- Related background / historical context query
+- Opposing or critical perspective query
+- English query (if the topic has international relevance)
+
+### Step 2: Parallel Search
+Run all queries in parallel using `search_news`:
+- Brave searches with freshness=pm (past month)
+- At least one YouTube search for the main topic
+Present a combined, deduplicated list of sources.
+
+### Step 3: Synthesis
+Analyze the collected results and present:
+1. **概要**: What is happening and why it matters
+2. **タイムライン**: Key events in chronological order
+3. **複数の視点**: At least 2-3 viewpoints with supporting sources
+4. **情報ギャップ**: What is unclear or missing from available sources
+5. **ソース品質**: Which sources appear most reliable and why
+
+### Step 4: Episode Suggestion
+Ask the user if they want to create an episode from the research results.
+If yes, recommend which articles to include and use `create_episode_from_articles`.
+
+## Notes
+- Clearly attribute each claim to its source
+- Flag potentially biased sources
+- Acknowledge what you could NOT find or verify
+- Present the synthesis in Japanese (matching the project's target audience)

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: status
+description: Quick overview of all episodes and their pipeline progress with actionable items
+---
+
+# /status — Episode Status Overview
+
+Show a quick overview of all episodes and highlight actionable items.
+
+## Workflow
+
+### Step 1: Health Check
+Use `health_check` to verify the backend is running.
+If not healthy, report the error and suggest `docker compose up -d`.
+
+### Step 2: List Episodes
+Use `list_episodes` to get all episodes.
+
+### Step 3: Present Dashboard
+For each episode, show a one-line pipeline progress bar using these icons:
+- `[v]` = approved
+- `[?]` = needs_approval
+- `[~]` = running
+- `[ ]` = pending
+- `[x]` = rejected
+
+Format:
+```
+#ID [status] タイトル (作成日)
+  [v]collection [v]factcheck [?]analysis [ ]script [ ]voice [ ]video
+```
+
+### Step 4: Action Items
+Highlight items that need attention:
+- Steps with `needs_approval` → "Episode #X の Y ステップが承認待ちです"
+- Steps with `running` → "Episode #X の Y ステップが実行中です"
+- Rejected steps → "Episode #X の Y ステップが却下されました"
+
+If no pending actions: "All clear — アクション待ちのエピソードはありません。"
+
+### Step 5: Quick Actions
+If there are actionable items, suggest:
+- "承認・実行: `/pipeline {episode_id}`"
+- "新規作成: `/episode`"


### PR DESCRIPTION
## Summary
- 7つのカスタムスラッシュコマンド（Skills）と5つのライフサイクルフック（Hooks）を追加
- 日常的なエピソード作成・パイプライン操作・公開ワークフローを効率化

## Skills
| Skill | 目的 |
|-------|------|
| `/status` | 全エピソードのパイプライン状況を一覧表示 |
| `/episode [topic]` | 検索→記事選択→エピソード作成の対話的フロー |
| `/pipeline <id>` | 次ステップの自動判定・実行・監視・承認 |
| `/research <topic>` | Brave+YouTube多角的調査＋統合レポート |
| `/note <id>` | note.com記事生成（前提確認・プレビュー・カバー画像） |
| `/costs [period]` | APIコスト分析＋最適化提案 |
| `/publish <id>` | Drive/note/完了マークの一括パブリッシュ |

## Hooks
| Event | 動作 |
|-------|------|
| SessionStart | バックエンドヘルスチェック＋承認待ち数を表示 |
| PostToolUse(run_step) | 完了まで15秒間隔で自動ポーリング（最大10分） |
| PostToolUse(approve_step) | 次ステップを自動提案 |
| PostToolUse(search_news) | エピソード作成を提案 |
| Stop | 承認待ちエピソードをリマインド |

## Test plan
- [ ] 新セッション開始時にヘルスチェック結果が表示される
- [ ] `/status` で全エピソードの進行状況が一覧表示される
- [ ] `/episode` でトピック入力から作成まで動く
- [ ] `/pipeline <id>` で次ステップの自動判定・実行が動く
- [ ] `run_step` 後にポーリングhookが完了を検知する
- [ ] `approve_step` 後に次ステップが提案される
- [ ] `/costs` でコストレポートが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)